### PR TITLE
fixed bug: escaping quotes on project description

### DIFF
--- a/project_initialization.py
+++ b/project_initialization.py
@@ -34,7 +34,7 @@ class CreateProject(luigi.Task):
               'password'	: config['catalog_pass'],
               'name'		: self.name,
               'organization'	: self.organization,
-              'description'	: self.description,
+              'description'	: self.description.replace("\"", "\\\""),
               'alias'		: self.alias}
     shellout_no_stdout(command, **kwargs)
     
@@ -100,7 +100,7 @@ class CreateStudy(luigi.Task):
               'user'		: config['catalog_user'],
               'password'	: config['catalog_pass'],
               'name'		: self.name,
-              'description'	: self.description,
+              'description'	: self.description.replace("\"", "\\\""),
               'alias'		: self.alias,
               'project-alias'	: self.project_alias}
     


### PR DESCRIPTION
with descriptions as:
"This project uses "funny quotes" to screw every one else"

we end up calling opencga like:
...opencga.sh ... -d "This project uses "funny quotes" to screw everyone else" ...

which gets interpreted as if the description was `-d  "This project uses funny"`and an extra parameter `quotes" to screw everyone else"` whithout arguments, what results in:
```
Was passed main parameter 'quotes" to screw everyone else"' but no main parameter was defined
```