### PR TITLE
Parameters not necessary in external properties files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Skeletons to load genotyped and aggregated VCF files are provided in the `exampl
 `application.properties` is used to configure database connections and applications the pipeline depends on: 
 [OpenCGA](https://github.com/opencb/opencga/tree/hotfix/0.5) and [Ensembl VEP](http://www.ensembl.org/info/docs/tools/vep/index.html).
 
-`load-genotyped-vcf.properties` and `load-aggregated-vcf.properties` are job-specific configurations.
+`load-genotyped-vcf.properties`, `load-aggregated-vcf.properties` and `initialize-database.properties` are job-specific configurations.
 
 If more convenient for your use case, the global and job configuration files can be merged into one.
 
@@ -41,9 +41,8 @@ the location of your MongoDB databases, your OpenCGA/VEP installation directory,
 
 By using these properties files, a job can be launched with a single command like:
 
-    java -jar target/eva-pipeline-0.1.jar --spring.config.name=application,load-genotyped-vcf
-
-Please note the `.properties` extension must not be specified.
+    java -jar target/eva-pipeline-0.1.jar \
+        --spring.config.location=file:examples/application.properties,file:examples/load-genotyped-vcf.properties
 
 The contents from the configuration files can be provided directly as command-line arguments, like the following:
 

--- a/examples/application.properties
+++ b/examples/application.properties
@@ -4,29 +4,10 @@
 spring.profiles.active=production
 
 
-# SUBMISSION FIELDS
-input.vcf=
-input.vcf.id=
-input.vcf.aggregation=NONE
-input.study.type=COLLECTION
-input.study.name=
-input.study.id=
-input.pedigree=
-input.gtf=
-input.fasta=
-
-output.dir=
-output.dir.annotation=
-
-
 # EXTERNAL APPLICATIONS
 app.opencga.path=/path/to/opencga
-
 app.vep.path=/path/to/variant_effect_predictor.pl
 app.vep.num-forks=4
-app.vep.cache.path=
-app.vep.cache.version=
-app.vep.cache.species=
 
 
 # STEPS MANAGEMENT

--- a/examples/initialize-database.properties
+++ b/examples/initialize-database.properties
@@ -1,19 +1,6 @@
 # JOB
 spring.batch.job.names=initialize-database
 
-
 # INITIALIZATION PARAMETERS
-input.gtf=
-
-
-# MONGO DATABASE
-db.collections.features.name=features
-
-
-# STEPS MANAGEMENT
-
-## Repeat steps
-## true: The already COMPLETED steps will be rerun. This is restarting the job from the beginning
-## false(default): if the job was aborted and is relaunched, COMPLETEd steps will NOT be done again
-config.restartability.allow=false
+input.gtf=/home/cyenyxe/tmp/sample.gtf.gz
 


### PR DESCRIPTION
External properties files don't need to define all the parameters, but they must be pointed to using `spring.config.location` (specific paths) instead of `spring.config.name` ("regex" that could end up excluding the internal application.properties).