### PR TITLE
EVA-447 Improved performance dumping variants to annotate

### DIFF
--- a/src/main/java/embl/ebi/variation/eva/pipeline/steps/readers/VariantReader.java
+++ b/src/main/java/embl/ebi/variation/eva/pipeline/steps/readers/VariantReader.java
@@ -4,28 +4,17 @@ import com.mongodb.DBObject;
 import embl.ebi.variation.eva.pipeline.MongoDBHelper;
 import org.opencb.datastore.core.ObjectMap;
 import org.springframework.batch.item.data.MongoItemReader;
-import org.springframework.data.domain.Sort;
-
-import java.util.HashMap;
-import java.util.Map;
-
 
 public class VariantReader extends MongoItemReader<DBObject> {
 
-    public VariantReader(ObjectMap pipelineOptions){
-        super();
-
+    public VariantReader(ObjectMap pipelineOptions) {
         setCollection(pipelineOptions.getString("db.collections.variants.name"));
 
-        setQuery("{ annot : { $exists : false } }");
-        setFields("{ chr : 1, start : 1, end : 1, ref : 1, alt : 1, type : 1}");
+        setQuery("{ \"annot.ct.so\" : { $exists : false } }");
+        setFields("{ chr : 1, start : 1, end : 1, ref : 1, alt : 1 }");
+        
         setTargetType(DBObject.class);
         setTemplate(MongoDBHelper.getMongoOperationsFromPipelineOptions(pipelineOptions));
-
-        Map<String, Sort.Direction> coordinatesSort = new HashMap<>();
-        coordinatesSort.put("chr", Sort.Direction.ASC);
-        coordinatesSort.put("start", Sort.Direction.ASC);
-        setSort(coordinatesSort);
     }
 
 }


### PR DESCRIPTION
Performance has improved approximately 10 times by doing the following:
* Removing unnecessary sort removed
* Removing unnecessary projected field "type"
* Searching using index on "annot.ct.so" field

It is not amazing yet though (~150 variants/sec), probably due to the use of paginated instead of cursor-based queries, but is it a start.