### PR TITLE
optionalAnnotationSteps_EVA-444

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/VariantJobsArgs.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/VariantJobsArgs.java
@@ -224,7 +224,7 @@ public class VariantJobsArgs {
         pipelineOptions.put(VariantStatsConfiguration.SKIP_STATS, skipStats);
 
         String annotationFilesPrefix = studyId + "_" + fileId;
-        pipelineOptions.put(VEP_INPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_variants_to_annotate.tsv.gz").toString());
+        pipelineOptions.put(VEP_INPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_variants_to_annotate.tsv").toString());
         pipelineOptions.put(VEP_OUTPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_vep_annotation.tsv.gz").toString());
         
         pipelineOptions.put(APP_VEP_PATH, vepPath);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/GzipLazyResource.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/GzipLazyResource.java
@@ -50,9 +50,5 @@ public class GzipLazyResource extends FileSystemResource {
         return new GZIPInputStream(super.getInputStream());
     }
 
-    public boolean isEmpty() throws IOException {
-        return getInputStream().read() == -1;
-    }
-
 }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/GzipLazyResource.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/GzipLazyResource.java
@@ -49,5 +49,10 @@ public class GzipLazyResource extends FileSystemResource {
     public InputStream getInputStream() throws IOException {
         return new GZIPInputStream(super.getInputStream());
     }
+
+    public boolean isEmpty() throws IOException {
+        return getInputStream().read() == -1;
+    }
+
 }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantAnnotConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantAnnotConfiguration.java
@@ -45,6 +45,10 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.VariantsAnnotLoad;
  * 2) annotationCreate - run VEP
  * 3) variantAnnotLoadBatchStep - Load VEP annotations into mongo
  *
+ * Optional flow: variantsAnnotGenerateInput --> (annotationCreate --> variantAnnotLoad)
+ * annotationCreate and variantAnnotLoad steps are only executed if variantsAnnotGenerateInput is generating a
+ * non-empty VEP input file
+ *
  */
 
 @Configuration

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfiguration.java
@@ -41,7 +41,7 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.VariantsTransform;
  *
  *                       |--> (optionalVariantStatsFlow: statsCreate --> statsLoad)
  *  transform ---> load -+
- *                       |--> (optionalVariantAnnotationFlow: variantsAnnotGenerateInput --> annotationCreate --> variantAnnotLoad)
+ *                       |--> (optionalVariantAnnotationFlow: variantsAnnotGenerateInput --> (annotationCreate --> variantAnnotLoad))
  *
  *  Steps in () are optional
  */

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfiguration.java
@@ -39,9 +39,9 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.VariantsTransform;
 /**
  *  Complete pipeline workflow:
  *
- *                       |--> (variantStatsFlow: statsCreate --> statsLoad)
+ *                       |--> (optionalVariantStatsFlow: statsCreate --> statsLoad)
  *  transform ---> load -+
- *                       |--> (variantAnnotationFlow: variantsAnnotGenerateInput --> annotationCreate --> variantAnnotLoad)
+ *                       |--> (optionalVariantAnnotationFlow: variantsAnnotGenerateInput --> annotationCreate --> variantAnnotLoad)
  *
  *  Steps in () are optional
  */
@@ -60,9 +60,9 @@ public class VariantConfiguration extends CommonJobStepInitialization{
     @Autowired
     private JobBuilderFactory jobBuilderFactory;
     @Autowired
-    private Flow variantAnnotationFlow;
+    private Flow optionalVariantAnnotationFlow;
     @Autowired
-    private Flow variantStatsFlow;
+    private Flow optionalVariantStatsFlow;
 
     @Autowired
     private VariantsLoad variantsLoad;
@@ -78,7 +78,7 @@ public class VariantConfiguration extends CommonJobStepInitialization{
 
         Flow parallelStatsAndAnnotation = new FlowBuilder<Flow>(PARALLEL_STATISTICS_AND_ANNOTATION)
                 .split(new SimpleAsyncTaskExecutor())
-                .add(variantStatsFlow, variantAnnotationFlow)
+                .add(optionalVariantStatsFlow, optionalVariantAnnotationFlow)
                 .build();
 
         FlowJobBuilder builder = jobBuilder

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantStatsConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/VariantStatsConfiguration.java
@@ -63,12 +63,12 @@ public class VariantStatsConfiguration extends CommonJobStepInitialization{
                 .incrementer(new RunIdIncrementer());
 
         return jobBuilder
-                .start(variantStatsFlow())
+                .start(optionalVariantStatsFlow())
                 .build().build();
     }
 
     @Bean
-    public Flow variantStatsFlow(){
+    public Flow optionalVariantStatsFlow(){
         OptionalDecider statisticsOptionalDecider = new OptionalDecider(getPipelineOptions(), SKIP_STATS);
 
         return new FlowBuilder<Flow>(STATS_FLOW)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/EmptyFileDecider.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/EmptyFileDecider.java
@@ -29,7 +29,7 @@ import java.nio.file.Paths;
 /**
  * @author Diego Poggioli
  *
- *
+ * Decider used to skip step(s) in case a previous step is generating an empty file
  */
 public class EmptyFileDecider implements JobExecutionDecider {
     private static final Logger logger = LoggerFactory.getLogger(EmptyFileDecider.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/EmptyFileDecider.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/EmptyFileDecider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.jobs.deciders;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.flow.FlowExecutionStatus;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * @author Diego Poggioli
+ *
+ *
+ */
+public class EmptyFileDecider implements JobExecutionDecider {
+    private static final Logger logger = LoggerFactory.getLogger(EmptyFileDecider.class);
+
+    private String file;
+
+    public static final String STOP_FLOW = "STOP_FLOW";
+    public static final String CONTINUE_FLOW = "CONTINUE_FLOW";
+
+    public EmptyFileDecider(String file) {
+        this.file =file;
+    }
+
+    @Override
+    public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
+
+        if (getFileSize() <= 0) {
+            logger.info("File {} is empty so following steps will not run", file);
+            return new FlowExecutionStatus(STOP_FLOW);
+        }
+
+        return new FlowExecutionStatus(CONTINUE_FLOW);
+    }
+
+    private long getFileSize(){
+        long fileSize;
+
+        try {
+            fileSize = Files.size(Paths.get(file));
+        } catch (IOException e) {
+            throw new RuntimeException("File {} is not readable", e);
+        }
+        return fileSize;
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfigurationWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfigurationWorkflowTest.java
@@ -148,6 +148,9 @@ public class VariantConfigurationWorkflowTest {
         initVariantConfigurationJob();
         variantJobsArgs.getPipelineOptions().put(VariantStatsConfiguration.SKIP_STATS, true);
 
+        variantJobsArgs.getPipelineOptions().put("db.name", "diegoTest");
+
+
         JobExecution execution = jobLauncherTestUtils.launchJob();
 
         assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantsAnnotCreateTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantsAnnotCreateTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.jobs.steps;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfig;
+import uk.ac.ebi.eva.pipeline.configuration.VariantJobsArgs;
+import uk.ac.ebi.eva.pipeline.jobs.VariantAnnotConfiguration;
+import uk.ac.ebi.eva.pipeline.jobs.VariantAnnotConfigurationTest;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.zip.GZIPInputStream;
+
+import static junit.framework.TestCase.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.makeGzipFile;
+
+/**
+ * @author Diego Poggioli
+ *
+ * Test for {@link VariantsAnnotCreate}
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { VariantJobsArgs.class, VariantAnnotConfiguration.class, AnnotationConfig.class, JobLauncherTestUtils.class})
+public class VariantsAnnotCreateTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    @Autowired
+    private VariantJobsArgs variantJobsArgs;
+
+    @Before
+    public void setUp() throws Exception {
+        variantJobsArgs.loadArgs();
+        File vepPathFile = new File(VariantAnnotConfigurationTest.class.getResource("/mockvep.pl").getFile());
+        variantJobsArgs.setAppVepPath(vepPathFile);
+    }
+
+    @Test
+    public void shouldGenerateAnnotations() throws Exception {
+        makeGzipFile("20\t60343\t60343\tG/A\t+", variantJobsArgs.getVepInput());
+
+        File vepOutputFile = JobTestUtils.createTempFile();
+        variantJobsArgs.setVepOutput(vepOutputFile.getAbsolutePath());
+
+        vepOutputFile.delete();
+        TestCase.assertFalse(vepOutputFile.exists());  // ensure the annot file doesn't exist from previous executions
+
+        // When the execute method in variantsAnnotCreate is executed
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(VariantAnnotConfiguration.GENERATE_VEP_ANNOTATION);
+
+        //Then variantsAnnotCreate step should complete correctly
+        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+
+        // And VEP output should exist and annotations should be in the file
+        TestCase.assertTrue(vepOutputFile.exists());
+        Assert.assertEquals(537, JobTestUtils.getLines(new GZIPInputStream(new FileInputStream(vepOutputFile))));
+        vepOutputFile.delete();
+    }
+
+}


### PR DESCRIPTION
- New decider implemented to check that there are variants to annotate before running VEP. If the VEP input file is empty then VEP and annotations load will not run.
- Removed extension .gz to the vep input file

EVA-444