### PR TITLE
bugFix: multiple run of VariantAnnotationMongoItemWriter overwrite annotations

### DIFF
--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantAnnotationWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantAnnotationWriterTest.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.eva.pipeline.io.writers;
 
 import com.mongodb.*;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
@@ -14,17 +15,14 @@ import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfig;
 import uk.ac.ebi.eva.pipeline.configuration.VariantJobsArgs;
 import uk.ac.ebi.eva.pipeline.io.mappers.VariantAnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.jobs.VariantAnnotConfiguration;
-import uk.ac.ebi.eva.test.data.VepOutputContent;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { VariantAnnotConfiguration.class, AnnotationConfig.class})
@@ -33,42 +31,30 @@ public class VariantAnnotationWriterTest {
     @Autowired
     private VariantJobsArgs variantJobsArgs;
 
+    private DBObjectToVariantAnnotationConverter converter;
+    private MongoOperations mongoOperations;
+    private MongoClient mongoClient;
+    private VariantAnnotationMongoItemWriter annotationWriter;
+    private VariantAnnotationLineMapper variantAnnotationLineMapper;
+
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String dbName = variantJobsArgs.getDbName();
         String dbCollectionVariantsName = variantJobsArgs.getDbCollectionsVariantsName();
         JobTestUtils.cleanDBs(dbName);
 
-        // first do a mock of a "variants" collection, with just the _id
-        VariantAnnotationLineMapper lineMapper = new VariantAnnotationLineMapper();
         List<VariantAnnotation> annotations = new ArrayList<>();
-        for (String annotLine : VepOutputContent.vepOutputContent.split("\n")) {
-            annotations.add(lineMapper.mapLine(annotLine, 0));
+        for (String annotLine : vepOutputContent.split("\n")) {
+            annotations.add(variantAnnotationLineMapper.mapLine(annotLine, 0));
         }
-        MongoClient mongoClient = new MongoClient();
-        DBCollection variants =
-                mongoClient.getDB(dbName).getCollection(dbCollectionVariantsName);
-        DBObjectToVariantAnnotationConverter converter = new DBObjectToVariantAnnotationConverter();
+        DBCollection variants = mongoClient.getDB(dbName).getCollection(dbCollectionVariantsName);
 
-        Set<String> uniqueIdsLoaded = new HashSet<>();
-        for (VariantAnnotation annotation : annotations) {
-            String id = MongoDBHelper.buildStorageId(
-                    annotation.getChromosome(),
-                    annotation.getStart(),
-                    annotation.getReferenceAllele(),
-                    annotation.getAlternativeAllele());
-
-            if (!uniqueIdsLoaded.contains(id)){
-                variants.insert(new BasicDBObject("_id", id));
-                uniqueIdsLoaded.add(id);
-            }
-
-        }
+        // first do a mock of a "variants" collection, with just the _id
+        writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
         MongoOperations mongoOperations = MongoDBHelper.getMongoOperationsFromPipelineOptions(variantJobsArgs.getPipelineOptions());
-        VariantAnnotationMongoItemWriter annotationWriter = new VariantAnnotationMongoItemWriter(mongoOperations, dbCollectionVariantsName);
-
+        annotationWriter = new VariantAnnotationMongoItemWriter(mongoOperations, dbCollectionVariantsName);
         annotationWriter.write(annotations);
 
         // and finally check that documents in DB have annotation (only consequence type)
@@ -84,6 +70,90 @@ public class VariantAnnotationWriterTest {
         }
         assertTrue(cnt>0);
         assertEquals(annotations.size(), consequenceTypeCount);
+    }
+
+    @Test
+    public void shouldWriteAllFieldsIntoMongoDbMultipleSetsAnnotations() throws Exception {
+        String dbName = variantJobsArgs.getDbName();
+        String dbCollectionVariantsName = variantJobsArgs.getPipelineOptions().getString("db.collections.variants.name");
+        JobTestUtils.cleanDBs(dbName);
+
+        List<VariantAnnotation> annotations = new ArrayList<>();
+        for (String annotLine : vepOutputContent.split("\n")) {
+            annotations.add(variantAnnotationLineMapper.mapLine(annotLine, 0));
+        }
+        DBCollection variants = mongoClient.getDB(dbName).getCollection(dbCollectionVariantsName);
+
+        // first do a mock of a "variants" collection, with just the _id
+        writeIdsIntoMongo(annotations, variants);
+
+        //prepare annotation sets
+        List<VariantAnnotation> annotationSet1 = new ArrayList<>();
+        List<VariantAnnotation> annotationSet2 = new ArrayList<>();
+        List<VariantAnnotation> annotationSet3 = new ArrayList<>();
+
+        String[] vepOutputLines = vepOutputContent.split("\n");
+
+        for (String annotLine : Arrays.copyOfRange(vepOutputLines, 0, 2)) {
+            annotationSet1.add(variantAnnotationLineMapper.mapLine(annotLine, 0));
+        }
+
+        for (String annotLine : Arrays.copyOfRange(vepOutputLines, 2, 4)) {
+            annotationSet2.add(variantAnnotationLineMapper.mapLine(annotLine, 0));
+        }
+
+        for (String annotLine : Arrays.copyOfRange(vepOutputLines, 4, 7)) {
+            annotationSet3.add(variantAnnotationLineMapper.mapLine(annotLine, 0));
+        }
+
+        // now, load the annotation
+        String collections = variantJobsArgs.getPipelineOptions().getString("db.collections.variants.name");
+        annotationWriter = new VariantAnnotationMongoItemWriter(mongoOperations, collections);
+
+        annotationWriter.write(annotationSet1);
+        annotationWriter.write(annotationSet2);
+        annotationWriter.write(annotationSet3);
+
+        // and finally check that documents in DB have the correct number of annotation
+        DBCursor cursor = variants.find();
+
+        while (cursor.hasNext()) {
+            DBObject dbObject = cursor.next();
+            String id = dbObject.get("_id").toString();
+
+            VariantAnnotation annot = converter.convertToDataModelType((DBObject) dbObject.get("annot"));
+
+            if(id.equals("20_63360_C_T") || id.equals("20_63399_G_A") || id.equals("20_63426_G_T")){
+                assertEquals(2, annot.getConsequenceTypes().size());
+                assertEquals(4, annot.getXrefs().size());
+            }
+
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        converter = new DBObjectToVariantAnnotationConverter();
+        mongoOperations = MongoDBHelper.getMongoOperationsFromPipelineOptions(variantJobsArgs.getPipelineOptions());
+        mongoClient = new MongoClient();
+        variantAnnotationLineMapper = new VariantAnnotationLineMapper();
+    }
+
+    private void writeIdsIntoMongo(List<VariantAnnotation> annotations, DBCollection variants) throws Exception {
+        Set<String> uniqueIdsLoaded = new HashSet<>();
+        for (VariantAnnotation annotation : annotations) {
+            String id = MongoDBHelper.buildStorageId(
+                    annotation.getChromosome(),
+                    annotation.getStart(),
+                    annotation.getReferenceAllele(),
+                    annotation.getAlternativeAllele());
+
+            if (!uniqueIdsLoaded.contains(id)){
+                variants.insert(new BasicDBObject("_id", id));
+                uniqueIdsLoaded.add(id);
+            }
+
+        }
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantAnnotConfigurationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantAnnotConfigurationTest.java
@@ -113,7 +113,7 @@ public class VariantAnnotConfigurationTest {
         }
 
         assertEquals(300, cnt);
-        assertEquals(533, consequenceTypeCount);
+        assertEquals(536, consequenceTypeCount);
 
         //check that one line is skipped because malformed
         List<StepExecution> variantAnnotationLoadStepExecution = jobExecution.getStepExecutions().stream()

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfigurationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/VariantConfigurationTest.java
@@ -330,7 +330,7 @@ public class VariantConfigurationTest {
         }
 
         assertEquals(300, cnt);
-        assertEquals(533, consequenceTypeCount);
+        assertEquals(536, consequenceTypeCount);
 
         //check that one line is skipped because malformed
         List<StepExecution> variantAnnotationLoadStepExecution = jobExecution.getStepExecutions().stream()


### PR DESCRIPTION
uk.ac.ebi.eva.pipeline.io.writers.VariantAnnotationMongoItemWriter#doWrite has been updated using now the mongo $addToSet option. In this way annotations from previous batches are not overwritten by the new one. Using $addToSet to avoid duplicates and $each to append all the annotations for each id. 
Tests updated accordingly

EVA-460