### PR TITLE
EVA-477 using mongo-java-driver 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>postgresql</artifactId>
             <version>9.1-901-1.jdbc4</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>2.14.2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>


### PR DESCRIPTION
using either a local mongo 3.0 or 3.2 all tests pass.
a small manual load works as well.

diff of `mvn dependency:tree`:

```
[INFO] +- postgresql:postgresql:jar:9.1-901-1.jdbc4:compile        [INFO] +- postgresql:postgresql:jar:9.1-901-1.jdbc4:compile
[INFO] +- org.mongodb:mongo-java-driver:jar:2.14.2:compile      <
[INFO] +- org.springframework.data:spring-data-mongodb:jar:1.8.    [INFO] +- org.springframework.data:spring-data-mongodb:jar:1.8.
[INFO] |  +- org.springframework:spring-tx:jar:4.2.5.RELEASE:co    [INFO] |  +- org.springframework:spring-tx:jar:4.2.5.RELEASE:co
[INFO] |  +- org.springframework:spring-context:jar:4.2.5.RELEA    [INFO] |  +- org.springframework:spring-context:jar:4.2.5.RELEA
[INFO] |  +- org.springframework:spring-beans:jar:4.2.5.RELEASE    [INFO] |  +- org.springframework:spring-beans:jar:4.2.5.RELEASE
[INFO] |  +- org.springframework:spring-expression:jar:4.2.5.RE    [INFO] |  +- org.springframework:spring-expression:jar:4.2.5.RE
[INFO] |  +- org.springframework.data:spring-data-commons:jar:1    [INFO] |  +- org.springframework.data:spring-data-commons:jar:1
                                                                >  [INFO] |  +- org.mongodb:mongo-java-driver:jar:2.13.3:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.16:compile           [INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.16:compile
```