### PR TITLE
EVA-490 fix qualifier name colision in job and step names

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
@@ -25,9 +25,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * Main entry point. spring boot takes care of autowiring everything with the JobLauncherCommandLineRunner.
  * By default, no job will be run on startup. Use this to launch any job:
  *
- *     java -jar target/gs-batch-processing-0.1.0.jar --spring.batch.job.names=variantJob
+ *     java -jar target/eva-pipeline-0.1.jar --spring.batch.job.names=load-genotyped-vcf
  *
- * append any parameter needed. See VariantJobParametersListener to know some of them.
+ * append any parameter needed.
  * TODO document all parameters
  *
  */

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
@@ -77,7 +77,7 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
 
     @Bean
     @Qualifier("variantJobAggregated")
-    public Job variantJob() {
+    public Job variantJobAggregated() {
         logger.debug("Building variant aggregated job");
 
         JobBuilder jobBuilder = jobBuilderFactory

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
@@ -18,7 +18,6 @@ package uk.ac.ebi.eva.pipeline.jobs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.job.builder.FlowJobBuilder;
@@ -31,9 +30,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import org.springframework.context.annotation.Scope;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
-import uk.ac.ebi.eva.pipeline.jobs.steps.VariantNormalizerStep;
 
 import javax.annotation.PostConstruct;
 
@@ -41,7 +38,7 @@ import javax.annotation.PostConstruct;
  *  Complete pipeline workflow for aggregated VCF.
  *  Aggregated statistics are provided in the VCF instead of the genotypes.
  *
- *  transform ---> load --> (optionalVariantAnnotationFlow: variantsAnnotGenerateInput --> (annotationCreate --> variantAnnotLoad))
+ *  transform ---> load --> (optionalAnnotationFlow: variantsAnnotGenerateInput --> (annotationCreate --> annotationLoad))
  *
  *  Steps in () are optional
  */
@@ -53,8 +50,6 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
     private static final Logger logger = LoggerFactory.getLogger(AggregatedVcfJob.class);
 
     private static final String jobName = "load-aggregated-vcf";
-    public static final String NORMALIZE_VARIANTS = "Normalize variants";
-    public static final String LOAD_VARIANTS = "Load variants";
 
     //job default settings
     private static final boolean INCLUDE_SAMPLES = false;
@@ -71,13 +66,13 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
     @Autowired
     private JobBuilderFactory jobBuilderFactory;
     @Autowired
-    private Flow optionalVariantAnnotationFlow;
+    private Flow optionalAnnotationFlow;
     @Autowired
     private VariantLoaderStep variantLoaderStep;
 
     @Bean
-    @Qualifier("variantJobAggregated")
-    public Job variantJobAggregated() {
+    @Qualifier("aggregatedJob")
+    public Job aggregatedJob() {
         logger.debug("Building variant aggregated job");
 
         JobBuilder jobBuilder = jobBuilderFactory
@@ -85,22 +80,12 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
                 .incrementer(new RunIdIncrementer());
 
         FlowJobBuilder builder = jobBuilder
-                .flow(transform())
-                .next(load())
-                .next(optionalVariantAnnotationFlow)
+                .flow(normalize())
+                .next(load(variantLoaderStep))
+                .next(optionalAnnotationFlow)
                 .end();
 
         return builder.build();
-    }
-
-    @Bean
-    @Scope("prototype")
-    protected Step transform() {
-        return generateStep(NORMALIZE_VARIANTS, new VariantNormalizerStep(getVariantOptions(), getPipelineOptions()));
-    }
-
-    private Step load() {
-        return generateStep(LOAD_VARIANTS, variantLoaderStep);
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/CommonJobStepInitialization.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/CommonJobStepInitialization.java
@@ -22,9 +22,13 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.builder.TaskletStepBuilder;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
+import org.springframework.context.annotation.Scope;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
+import uk.ac.ebi.eva.pipeline.jobs.steps.VariantNormalizerStep;
 
 /**
  * Helper class to build jobs.
@@ -33,6 +37,9 @@ import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
  */
 @Import({JobOptions.class})
 public abstract class CommonJobStepInitialization {
+
+    public static final String NORMALIZE_VARIANTS = "Normalize variants";
+    public static final String LOAD_VARIANTS = "Load variants";
 
     @Autowired
     private JobOptions jobOptions;
@@ -58,6 +65,16 @@ public abstract class CommonJobStepInitialization {
         final TaskletStepBuilder taskletBuilder = step1.tasklet(tasklet);
         initStep(taskletBuilder);
         return taskletBuilder.build();
+    }
+
+    @Bean
+    @Scope("prototype")
+    protected Step normalize() {
+        return generateStep(NORMALIZE_VARIANTS, new VariantNormalizerStep(getVariantOptions(), getPipelineOptions()));
+    }
+
+    protected Step load(VariantLoaderStep variantLoaderStep) {
+        return generateStep(LOAD_VARIANTS, variantLoaderStep);
     }
 
     public ObjectMap getPipelineOptions() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJob.java
@@ -61,18 +61,18 @@ public class PopulationStatisticsJob extends CommonJobStepInitialization{
     private PopulationStatisticsLoaderStep populationStatisticsLoaderStep;
 
     @Bean
-    public Job variantStatsJob() {
+    public Job variantStatisticsJob() {
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(jobName)
                 .incrementer(new RunIdIncrementer());
 
         return jobBuilder
-                .start(optionalVariantStatsFlow())
+                .start(optionalStatisticsFlow())
                 .build().build();
     }
 
     @Bean
-    public Flow optionalVariantStatsFlow(){
+    public Flow optionalStatisticsFlow(){
         SkipStepDecider statisticsSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_STATS);
 
         return new FlowBuilder<Flow>(STATS_FLOW)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
@@ -67,8 +67,8 @@ public class AnnotationLoaderStep {
     private JobOptions jobOptions;
 
     @Bean
-    @Qualifier("variantAnnotLoad")
-    public Step variantAnnotLoadBatchStep() throws IOException {
+    @Qualifier("annotationLoad")
+    public Step annotationLoadBatchStep() throws IOException {
         MongoOperations mongoOperations = MongoDBHelper.getMongoOperationsFromPipelineOptions(jobOptions.getPipelineOptions());
         String collections = jobOptions.getPipelineOptions().getString("db.collections.variants.name");
         VepAnnotationMongoWriter writer = new VepAnnotationMongoWriter(mongoOperations, collections);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -60,7 +60,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
 public class AggregatedVcfJobTest {
 
     @Autowired
-    @Qualifier("variantJobAggregated")
+    @Qualifier("aggregatedJob")
     public Job job;
     @Autowired
     private JobOptions jobOptions;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -64,7 +64,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.*;
  * Test for {@link GenotypedVcfJob}
  *
  * JobLauncherTestUtils is initialized in @Before because in GenotypedVcfJob there are two Job beans:
- * variantJob and variantAnnotationBatchJob (used by test). In this way it is possible to specify the Job to run
+ * genotypedJob and variantAnnotationBatchJob (used by test). In this way it is possible to specify the Job to run
  * and avoid NoUniqueBeanDefinitionException. There are also other solutions like:
  *  - http://stackoverflow.com/questions/29655796/how-can-i-qualify-an-autowired-setter-that-i-dont-own
  *  - https://jira.spring.io/browse/BATCH-2366
@@ -88,7 +88,7 @@ public class GenotypedVcfJobTest {
     private JobRepository jobRepository;
 
     @Autowired
-    @Qualifier("variantJob")
+    @Qualifier("genotypedJob")
     public Job job;
 
     private String input;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -66,7 +66,7 @@ public class GenotypedVcfJobWorkflowTest {
     private JobLauncher jobLauncher;
 
     @Autowired
-    @Qualifier("variantJob")
+    @Qualifier("genotypedJob")
     public Job job;
 
     private String inputFileResouce;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -68,7 +68,7 @@ public class VariantLoaderStepTest {
     private JobRepository jobRepository;
 
     @Autowired
-    @Qualifier("variantJob")
+    @Qualifier("genotypedJob")
     public Job job;
 
     private String input;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
@@ -67,7 +67,7 @@ public class VariantNormalizerStepTest extends CommonJobStepInitialization {
     private JobRepository jobRepository;
 
     @Autowired
-    @Qualifier("variantJob")
+    @Qualifier("genotypedJob")
     public Job job;
 
     private String input;


### PR DESCRIPTION
the first commit fixes the next bug, which makes the "load-genotyped-vcf" job unlaunchable: 
 
```
2016-10-06 15:54:36.945  INFO 18122 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Overriding bean definition for bean 'variantJob' with a different definition: replacing [Root bean: class [null]; scope=; abstract=false; lazyInit=false; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=genotypedVcfJob; factoryMethodName=variantJob; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.class]] with [Root bean: class [null]; scope=; abstract=false; lazyInit=false; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=aggregatedVcfJob; factoryMethodName=variantJob; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.class]]
```

but there are other warnings that may be important:

```
2016-10-06 15:54:36.945  INFO 18122 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Overriding bean definition for bean 'transform' with a different definition: replacing [Root bean: class [null]; scope=prototype; abstract=false; lazyInit=false; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=genotypedVcfJob; factoryMethodName=transform; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.class]] with [Root bean: class [null]; scope=prototype; abstract=false; lazyInit=false; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=aggregatedVcfJob; factoryMethodName=transform; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.class]]
2016-10-06 15:54:37.225  WARN 18122 --- [           main] o.s.c.a.ConfigurationClassEnhancer       : @Bean method ScopeConfiguration.stepScope is non-static and returns an object assignable to Spring's BeanFactoryPostProcessor interface. This will result in a failure to process annotations such as @Autowired, @Resource and @PostConstruct within the method's declaring @Configuration class. Add the 'static' modifier to this method to avoid these container lifecycle issues; see @Bean javadoc for complete details.
2016-10-06 15:54:37.235  WARN 18122 --- [           main] o.s.c.a.ConfigurationClassEnhancer       : @Bean method ScopeConfiguration.jobScope is non-static and returns an object assignable to Spring's BeanFactoryPostProcessor interface. This will result in a failure to process annotations such as @Autowired, @Resource and @PostConstruct within the method's declaring @Configuration class. Add the 'static' modifier to this method to avoid these container lifecycle issues; see @Bean javadoc for complete details.
```