### PR TITLE
EVA-488 Remove inter-test dependencies

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
+import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 
 import java.nio.file.Paths;
 import java.util.Properties;
@@ -218,7 +219,7 @@ public class JobOptions {
         pipelineOptions.put("config.db.password", dbPassword);
         pipelineOptions.put("config.db.read-preference", readPreference);
         pipelineOptions.put(AnnotationFlow.SKIP_ANNOT, skipAnnot);
-        pipelineOptions.put(PopulationStatisticsJob.SKIP_STATS, skipStats);
+        pipelineOptions.put(PopulationStatisticsFlow.SKIP_STATS, skipStats);
 
         String annotationFilesPrefix = studyId + "_" + fileId;
         pipelineOptions.put(VEP_INPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_variants_to_annotate.tsv").toString());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 
 import java.nio.file.Paths;
 import java.util.Properties;
@@ -216,7 +217,7 @@ public class JobOptions {
         pipelineOptions.put("config.db.user", dbUser);
         pipelineOptions.put("config.db.password", dbPassword);
         pipelineOptions.put("config.db.read-preference", readPreference);
-        pipelineOptions.put(AnnotationJob.SKIP_ANNOT, skipAnnot);
+        pipelineOptions.put(AnnotationFlow.SKIP_ANNOT, skipAnnot);
         pipelineOptions.put(PopulationStatisticsJob.SKIP_STATS, skipStats);
 
         String annotationFilesPrefix = studyId + "_" + fileId;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
+
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
 import uk.ac.ebi.eva.pipeline.listeners.VariantOptionsConfigurerListener;
 
@@ -44,7 +46,7 @@ import uk.ac.ebi.eva.pipeline.listeners.VariantOptionsConfigurerListener;
  */
 @Configuration
 @EnableBatchProcessing
-@Import({VariantLoaderStep.class, AnnotationJob.class})
+@Import({VariantLoaderStep.class, AnnotationFlow.class})
 public class AggregatedVcfJob extends CommonJobStepInitialization{
 
     private static final Logger logger = LoggerFactory.getLogger(AggregatedVcfJob.class);
@@ -60,7 +62,7 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
     @Autowired
     private JobBuilderFactory jobBuilderFactory;
     @Autowired
-    private Flow optionalAnnotationFlow;
+    private Flow annotationFlowOptional;
     @Autowired
     private VariantLoaderStep variantLoaderStep;
 
@@ -77,7 +79,7 @@ public class AggregatedVcfJob extends CommonJobStepInitialization{
         FlowJobBuilder builder = jobBuilder
                 .flow(normalize())
                 .next(load(variantLoaderStep))
-                .next(optionalAnnotationFlow)
+                .next(annotationFlowOptional)
                 .end();
 
         return builder.build();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
@@ -16,26 +16,18 @@
 
 package uk.ac.ebi.eva.pipeline.jobs;
 
-import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
-import org.springframework.batch.core.job.builder.FlowBuilder;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.job.flow.Flow;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import uk.ac.ebi.eva.pipeline.jobs.deciders.EmptyFileDecider;
-import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
-import uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep;
-import uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep;
-import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 
 /**
  * @author Diego Poggioli
@@ -53,65 +45,23 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 
 @Configuration
 @EnableBatchProcessing
-@Import({VepAnnotationGeneratorStep.class, VepInputGeneratorStep.class, AnnotationLoaderStep.class})
-public class AnnotationJob extends CommonJobStepInitialization{
+@Import({AnnotationFlow.class})
+public class AnnotationJob extends CommonJobStepInitialization {
     public static final String jobName = "annotate-variants";
-    public static final String SKIP_ANNOT = "annotation.skip";
-    public static final String GENERATE_VEP_ANNOTATION = "Generate VEP annotation";
-    private static final String OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW = "Optional variant VEP annotation flow";
-    private static final String VARIANT_VEP_ANNOTATION_FLOW = "Variant VEP annotation flow";
 
     @Autowired
     private JobBuilderFactory jobBuilderFactory;
 
-    @Qualifier("vepInputGeneratorStep")
     @Autowired
-    public Step variantsAnnotGenerateInputBatchStep;
-
-    @Qualifier("annotationLoad")
-    @Autowired
-    private Step annotationLoadBatchStep;
-
-    @Autowired
-    private VepAnnotationGeneratorStep vepAnnotationGeneratorStep;
-
+    private Flow annotationFlowBasic;
+    
     @Bean
     public Job variantAnnotationBatchJob(){
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(jobName)
                 .incrementer(new RunIdIncrementer());
 
-        return jobBuilder.start(optionalAnnotationFlow()).build().build();
-    }
-
-    @Bean
-    public Flow annotationFlow(){
-        EmptyFileDecider emptyFileDecider = new EmptyFileDecider(getPipelineOptions().getString("vep.input"));
-
-        return new FlowBuilder<Flow>(VARIANT_VEP_ANNOTATION_FLOW)
-                .start(variantsAnnotGenerateInputBatchStep)
-                .next(emptyFileDecider).on(EmptyFileDecider.CONTINUE_FLOW)
-                .to(annotationCreate())
-                .next(annotationLoadBatchStep)
-                .from(emptyFileDecider).on(EmptyFileDecider.STOP_FLOW)
-                .end(BatchStatus.COMPLETED.toString())
-                .build();
-    }
-
-    @Bean
-    public Flow optionalAnnotationFlow(){
-        SkipStepDecider annotationSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_ANNOT);
-
-        return new FlowBuilder<Flow>(OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW)
-                .start(annotationSkipStepDecider).on(SkipStepDecider.DO_STEP)
-                .to(annotationFlow())
-                .from(annotationSkipStepDecider).on(SkipStepDecider.SKIP_STEP)
-                .end(BatchStatus.COMPLETED.toString())
-                .build();
-    }
-
-    private Step annotationCreate() {
-        return generateStep(GENERATE_VEP_ANNOTATION, vepAnnotationGeneratorStep);
+        return jobBuilder.start(annotationFlowBasic).build().build();
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
@@ -63,7 +63,7 @@ public class GenotypedVcfJob extends CommonJobStepInitialization{
     @Autowired
     private JobBuilderFactory jobBuilderFactory;
     @Autowired
-    private Flow optionalAnnotationFlow;
+    private Flow annotationFlowOptional;
     @Autowired
     private Flow optionalStatisticsFlow;
     @Autowired
@@ -81,7 +81,7 @@ public class GenotypedVcfJob extends CommonJobStepInitialization{
 
         Flow parallelStatisticsAndAnnotation = new FlowBuilder<Flow>(PARALLEL_STATISTICS_AND_ANNOTATION)
                 .split(new SimpleAsyncTaskExecutor())
-                .add(optionalStatisticsFlow, optionalAnnotationFlow)
+                .add(optionalStatisticsFlow, annotationFlowOptional)
                 .build();
 
         FlowJobBuilder builder = jobBuilder

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
@@ -33,6 +33,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
+import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
 import uk.ac.ebi.eva.pipeline.listeners.VariantOptionsConfigurerListener;
 
@@ -47,7 +50,7 @@ import uk.ac.ebi.eva.pipeline.listeners.VariantOptionsConfigurerListener;
  */
 @Configuration
 @EnableBatchProcessing
-@Import({AnnotationJob.class, PopulationStatisticsJob.class, VariantLoaderStep.class})
+@Import({VariantLoaderStep.class, PopulationStatisticsFlow.class, AnnotationFlow.class})
 public class GenotypedVcfJob extends CommonJobStepInitialization{
     private static final Logger logger = LoggerFactory.getLogger(GenotypedVcfJob.class);
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
@@ -1,0 +1,72 @@
+package uk.ac.ebi.eva.pipeline.jobs.flows;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.FlowBuilder;
+import org.springframework.batch.core.job.flow.Flow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
+import uk.ac.ebi.eva.pipeline.jobs.deciders.EmptyFileDecider;
+import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
+import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
+import uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep;
+import uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep;
+
+@Configuration
+@EnableBatchProcessing
+@Import({VepAnnotationGeneratorStep.class, VepInputGeneratorStep.class, AnnotationLoaderStep.class})
+public class AnnotationFlow extends CommonJobStepInitialization {
+
+    public static final String SKIP_ANNOT = "annotation.skip";
+    public static final String GENERATE_VEP_ANNOTATION = "Generate VEP annotation";
+    private static final String OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW = "Optional variant VEP annotation flow";
+    private static final String VARIANT_VEP_ANNOTATION_FLOW = "Variant VEP annotation flow";
+
+    @Qualifier("vepInputGeneratorStep")
+    @Autowired
+    public Step variantsAnnotGenerateInputBatchStep;
+
+    @Qualifier("annotationLoad")
+    @Autowired
+    private Step annotationLoadBatchStep;
+
+    @Autowired
+    private VepAnnotationGeneratorStep vepAnnotationGeneratorStep;
+
+    @Bean
+    Flow annotationFlowOptional() {
+        SkipStepDecider annotationSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_ANNOT);
+
+        return new FlowBuilder<Flow>(OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW)
+                .start(annotationSkipStepDecider).on(SkipStepDecider.DO_STEP)
+                .to(annotationFlowBasic())
+                .from(annotationSkipStepDecider).on(SkipStepDecider.SKIP_STEP)
+                .end(BatchStatus.COMPLETED.toString())
+                .build();
+    }
+
+    @Bean
+    Flow annotationFlowBasic() {
+        EmptyFileDecider emptyFileDecider = new EmptyFileDecider(getPipelineOptions().getString("vep.input"));
+
+        return new FlowBuilder<Flow>(VARIANT_VEP_ANNOTATION_FLOW)
+                .start(variantsAnnotGenerateInputBatchStep)
+                .next(emptyFileDecider).on(EmptyFileDecider.CONTINUE_FLOW)
+                .to(annotationCreate())
+                .next(annotationLoadBatchStep)
+                .from(emptyFileDecider).on(EmptyFileDecider.STOP_FLOW)
+                .end(BatchStatus.COMPLETED.toString())
+                .build();
+    }
+
+    private Step annotationCreate() {
+        return generateStep(GENERATE_VEP_ANNOTATION, vepAnnotationGeneratorStep);
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/PopulationStatisticsFlow.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/PopulationStatisticsFlow.java
@@ -1,0 +1,53 @@
+package uk.ac.ebi.eva.pipeline.jobs.flows;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.FlowBuilder;
+import org.springframework.batch.core.job.flow.Flow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
+import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
+import uk.ac.ebi.eva.pipeline.jobs.steps.PopulationStatisticsGeneratorStep;
+import uk.ac.ebi.eva.pipeline.jobs.steps.PopulationStatisticsLoaderStep;
+
+@Configuration
+@EnableBatchProcessing
+@Import({PopulationStatisticsGeneratorStep.class, PopulationStatisticsLoaderStep.class})
+public class PopulationStatisticsFlow extends CommonJobStepInitialization {
+
+    public static final String SKIP_STATS = "statistics.skip";
+    public static final String CALCULATE_STATISTICS = "Calculate statistics";
+    public static final String LOAD_STATISTICS = "Load statistics";
+    private static final String STATS_FLOW = "statsFlow";
+    
+    @Autowired
+    private PopulationStatisticsGeneratorStep populationStatisticsGeneratorStep;
+
+    @Autowired
+    private PopulationStatisticsLoaderStep populationStatisticsLoaderStep;
+
+    @Bean
+    public Flow optionalStatisticsFlow(){
+        SkipStepDecider statisticsSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_STATS);
+
+        return new FlowBuilder<Flow>(STATS_FLOW)
+                .start(statisticsSkipStepDecider).on(SkipStepDecider.DO_STEP)
+                .to(statsCreate())
+                .next(statsLoad())
+                .from(statisticsSkipStepDecider).on(SkipStepDecider.SKIP_STEP).end(BatchStatus.COMPLETED.toString())
+                .build();
+    }
+
+    private Step statsCreate() {
+        return generateStep(CALCULATE_STATISTICS, populationStatisticsGeneratorStep);
+    }
+
+    private Step statsLoad() {
+        return generateStep(LOAD_STATISTICS, populationStatisticsLoaderStep);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/utils/ConnectionHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/ConnectionHelper.java
@@ -34,9 +34,6 @@ import java.util.List;
  */
 public class ConnectionHelper {
 
-    private static MongoClient mongoClientWithAuthentication;
-    private static MongoClient mongoClientWithOutAuthentication;
-
     public static List<ServerAddress> parseServerAddresses(String hosts) throws UnknownHostException {
         List<ServerAddress> serverAddresses = new LinkedList<>();
         for (String hostPort : hosts.split(",")) {
@@ -70,8 +67,7 @@ public class ConnectionHelper {
 
     public static MongoClient getMongoClient(String hosts, String authenticationDB,
                                              String user, char[] password) throws UnknownHostException {
-        if(mongoClientWithAuthentication == null){
-            mongoClientWithAuthentication = new MongoClient(
+    	return new MongoClient(
                     parseServerAddresses(hosts),
                     Collections.singletonList(MongoCredential.createCredential(
                             user,
@@ -79,15 +75,9 @@ public class ConnectionHelper {
                             password
                             )
                     ));
-        }
-
-        return mongoClientWithAuthentication;
     }
 
     public static MongoClient getMongoClient() throws UnknownHostException {
-        if(mongoClientWithOutAuthentication == null)
-            mongoClientWithOutAuthentication = new MongoClient();
-
-        return mongoClientWithOutAuthentication;
+    	return new MongoClient();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/utils/ConnectionHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/ConnectionHelper.java
@@ -67,7 +67,7 @@ public class ConnectionHelper {
 
     public static MongoClient getMongoClient(String hosts, String authenticationDB,
                                              String user, char[] password) throws UnknownHostException {
-    	return new MongoClient(
+        return new MongoClient(
                     parseServerAddresses(hosts),
                     Collections.singletonList(MongoCredential.createCredential(
                             user,
@@ -78,6 +78,6 @@ public class ConnectionHelper {
     }
 
     public static MongoClient getMongoClient() throws UnknownHostException {
-    	return new MongoClient();
+        return new MongoClient();
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/AnnotationJobConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/AnnotationJobConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.pipeline.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * @author Cristina Yenyxe Gonzalez Garcia
+ *
+ * Configuration init for AnnotationJob tests
+ */
+@Configuration
+@PropertySource({"annotation-job.properties"})
+public class AnnotationJobConfiguration {
+
+    @Bean
+    private static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/AnnotationLoaderStepConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/AnnotationLoaderStepConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.pipeline.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * @author Cristina Yenyxe Gonzalez Garcia
+ *
+ * Configuration init for AnnotationLoaderStep tests
+ */
+@Configuration
+@PropertySource({"annotation-loader-step.properties"})
+public class AnnotationLoaderStepConfiguration {
+
+    @Bean
+    private static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/VepInputGeneratorStepConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/VepInputGeneratorStepConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.pipeline.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * @author Cristina Yenyxe Gonzalez Garcia
+ *
+ * Configuration init for VepInputGeneratorStep tests
+ */
+@Configuration
+@PropertySource({"vep-input-generator-step.properties"})
+public class VepInputGeneratorStepConfiguration {
+
+    @Bean
+    private static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -65,6 +65,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
+        jobOptions.setDbName(getClass().getSimpleName());
     }
 
     @Test
@@ -88,8 +89,8 @@ public class NonAnnotatedVariantsMongoReaderTest {
     }
 
     @After
-    public void setDown(){
-        collection().drop();
+    public void tearDown() throws Exception {
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
     private DBCollection collection() {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -20,6 +20,8 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,11 +52,18 @@ public class GeneWriterTest {
     @Autowired
     private JobOptions jobOptions;
 
+    @Before
+    public void setUp() throws Exception {
+        jobOptions.setDbName(getClass().getSimpleName());
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
+    }
+    
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
-        String dbName = jobOptions.getDbName();
-        JobTestUtils.cleanDBs(dbName);
-
         GeneWriter geneWriter = new GeneWriter(jobOptions.getMongoOperations(), jobOptions.getDbCollectionsFeaturesName());
 
         GeneLineMapper lineMapper = new GeneLineMapper();
@@ -67,7 +76,7 @@ public class GeneWriterTest {
         geneWriter.write(genes);
 
         MongoClient mongoClient = new MongoClient();
-        DBCollection genesCollection = mongoClient.getDB(dbName).getCollection(jobOptions.getDbCollectionsFeaturesName());
+        DBCollection genesCollection = mongoClient.getDB(jobOptions.getDbName()).getCollection(jobOptions.getDbCollectionsFeaturesName());
 
         // count documents in DB and check they have region (chr + start + end)
         DBCursor cursor = genesCollection.find();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -15,8 +15,17 @@
  */
 package uk.ac.ebi.eva.pipeline.io.writers;
 
-import com.mongodb.*;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,18 +35,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
-
-import java.util.*;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 
 /**
  * {@link VepAnnotationMongoWriter}
@@ -62,7 +72,6 @@ public class VepAnnotationMongoWriterTest {
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String dbName = jobOptions.getDbName();
         String dbCollectionVariantsName = jobOptions.getDbCollectionsVariantsName();
-        JobTestUtils.cleanDBs(dbName);
 
         List<VariantAnnotation> annotations = new ArrayList<>();
         for (String annotLine : vepOutputContent.split("\n")) {
@@ -102,7 +111,6 @@ public class VepAnnotationMongoWriterTest {
     public void shouldWriteAllFieldsIntoMongoDbMultipleSetsAnnotations() throws Exception {
         String dbName = jobOptions.getDbName();
         String dbCollectionVariantsName = jobOptions.getPipelineOptions().getString("db.collections.variants.name");
-        JobTestUtils.cleanDBs(dbName);
 
         List<VariantAnnotation> annotations = new ArrayList<>();
         for (String annotLine : vepOutputContent.split("\n")) {
@@ -163,6 +171,15 @@ public class VepAnnotationMongoWriterTest {
         mongoOperations = MongoDBHelper.getMongoOperationsFromPipelineOptions(jobOptions.getPipelineOptions());
         mongoClient = new MongoClient();
         AnnotationLineMapper = new AnnotationLineMapper();
+
+        String dbName = jobOptions.getDbName();
+        JobTestUtils.cleanDBs(dbName);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        String dbName = jobOptions.getDbName();
+        JobTestUtils.cleanDBs(dbName);
     }
 
     private void writeIdsIntoMongo(List<VariantAnnotation> annotations, DBCollection variants) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -25,11 +25,8 @@ import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
 import org.springframework.batch.core.*;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -56,20 +53,15 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
  */
 @IntegrationTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {JobOptions.class, AggregatedVcfJob.class, VariantAggregatedConfig.class})
+@ContextConfiguration(classes = {JobOptions.class, AggregatedVcfJob.class, VariantAggregatedConfig.class, JobLauncherTestUtils.class})
 public class AggregatedVcfJobTest {
 
     @Autowired
-    @Qualifier("aggregatedJob")
-    public Job job;
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    
     @Autowired
     private JobOptions jobOptions;
-    @Autowired
-    private JobLauncher jobLauncher;
-    @Autowired
-    private JobRepository jobRepository;
 
-    private JobLauncherTestUtils jobLauncherTestUtils;
     private String input;
     private String outputDir;
     private String compressExtension;
@@ -161,11 +153,6 @@ public class AggregatedVcfJobTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-
-        jobLauncherTestUtils = new JobLauncherTestUtils();
-        jobLauncherTestUtils.setJob(job);
-        jobLauncherTestUtils.setJobLauncher(jobLauncher);
-        jobLauncherTestUtils.setJobRepository(jobRepository);
 
         input = jobOptions.getPipelineOptions().getString("input.vcf");
         outputDir = jobOptions.getPipelineOptions().getString("output.dir");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -46,7 +46,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.*;
 import static uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION;
 import static uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE;
@@ -69,36 +68,35 @@ public class AnnotationJobTest {
     private JobOptions jobOptions;
 
     private File vepInputFile;
-    private String dbName;
     private MongoClient mongoClient;
     private DBObjectToVariantAnnotationConverter converter;
 
     @Test
     public void allAnnotationStepsShouldBeExecuted () throws Exception {
-        String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        JobTestUtils.restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        String dump = PopulationStatisticsJobTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        JobTestUtils.restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
-        Assert.assertEquals(3, jobExecution.getStepExecutions().size());
+        assertEquals(3, jobExecution.getStepExecutions().size());
         List<StepExecution> steps = new ArrayList<>(jobExecution.getStepExecutions());
         StepExecution findVariantsToAnnotateStep = steps.get(0);
         StepExecution generateVepAnnotationsStep = steps.get(1);
         StepExecution loadVepAnnotationsStep = steps.get(2);
 
-        Assert.assertEquals(FIND_VARIANTS_TO_ANNOTATE, findVariantsToAnnotateStep.getStepName());
-        Assert.assertEquals(GENERATE_VEP_ANNOTATION, generateVepAnnotationsStep.getStepName());
-        Assert.assertEquals(LOAD_VEP_ANNOTATION, loadVepAnnotationsStep.getStepName());
+        assertEquals(FIND_VARIANTS_TO_ANNOTATE, findVariantsToAnnotateStep.getStepName());
+        assertEquals(GENERATE_VEP_ANNOTATION, generateVepAnnotationsStep.getStepName());
+        assertEquals(LOAD_VEP_ANNOTATION, loadVepAnnotationsStep.getStepName());
 
         //check list of variants without annotation output file
         assertTrue(vepInputFile.exists());
         assertEquals("20\t60343\t60343\tG/A\t+", JobTestUtils.readFirstLine(vepInputFile));
 
         //check that documents have the annotation
-        DBCursor cursor = collection(dbName, jobOptions.getDbCollectionsVariantsName()).find();
+        DBCursor cursor = collection(jobOptions.getDbName(), jobOptions.getDbCollectionsVariantsName()).find();
 
         int cnt=0;
         int consequenceTypeCount = 0;
@@ -124,7 +122,6 @@ public class AnnotationJobTest {
 
     @Test
     public void noVariantsToAnnotateOnlyFindVariantsToAnnotateStepShouldRun() throws Exception {
-
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
@@ -142,6 +139,7 @@ public class AnnotationJobTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
+        jobOptions.setDbName(getClass().getSimpleName());
         vepInputFile = new File(jobOptions.getVepInput());
 
         File vepPathFile = new File(AnnotationJobTest.class.getResource("/mockvep.pl").getFile());
@@ -149,8 +147,6 @@ public class AnnotationJobTest {
 
         converter = new DBObjectToVariantAnnotationConverter();
         mongoClient = new MongoClient();
-
-        dbName = jobOptions.getDbName();
     }
 
     /**
@@ -163,7 +159,7 @@ public class AnnotationJobTest {
         vepInputFile.delete();
         new File(jobOptions.getVepOutput()).delete();
 
-        JobTestUtils.cleanDBs(dbName);
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
     private DBCollection collection(String databaseName, String collectionName) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.AnnotationJobConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -58,7 +58,7 @@ import static uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep.LOAD_VEP_AN
  */
 @IntegrationTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { JobOptions.class, AnnotationJob.class, AnnotationConfiguration.class, JobLauncherTestUtils.class})
+@ContextConfiguration(classes = { JobOptions.class, AnnotationJob.class, AnnotationJobConfiguration.class, JobLauncherTestUtils.class})
 public class AnnotationJobTest {
 
     @Autowired
@@ -139,7 +139,6 @@ public class AnnotationJobTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobOptions.setDbName(getClass().getSimpleName());
         vepInputFile = new File(jobOptions.getVepInput());
 
         File vepPathFile = new File(AnnotationJobTest.class.getResource("/mockvep.pl").getFile());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -76,7 +76,7 @@ public class AnnotationJobTest {
     @Test
     public void allAnnotationStepsShouldBeExecuted () throws Exception {
         String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        JobTestUtils.restoreMongoDbFromDump(dump);
+        JobTestUtils.restoreMongoDbFromDump(dump, getClass().getSimpleName());
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -30,11 +30,8 @@ import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
 import org.springframework.batch.core.*;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -74,22 +71,14 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.*;
  */
 @IntegrationTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { JobOptions.class, GenotypedVcfJob.class, GenotypedVcfConfiguration.class})
+@ContextConfiguration(classes = { JobOptions.class, GenotypedVcfJob.class, GenotypedVcfConfiguration.class, JobLauncherTestUtils.class})
 public class GenotypedVcfJobTest {
 
+	@Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
     
     @Autowired
     private JobOptions jobOptions;
-
-    @Autowired
-    private JobLauncher jobLauncher;
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    @Qualifier("genotypedJob")
-    public Job job;
 
     private String input;
     private String outputDir;
@@ -220,10 +209,6 @@ public class GenotypedVcfJobTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobLauncherTestUtils = new JobLauncherTestUtils();
-        jobLauncherTestUtils.setJob(job);
-        jobLauncherTestUtils.setJobLauncher(jobLauncher);
-        jobLauncherTestUtils.setJobRepository(jobRepository);
 
         input = jobOptions.getPipelineOptions().getString("input.vcf");
         outputDir = jobOptions.getPipelineOptions().getString("output.dir");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -74,7 +74,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.*;
 @ContextConfiguration(classes = { JobOptions.class, GenotypedVcfJob.class, GenotypedVcfConfiguration.class, JobLauncherTestUtils.class})
 public class GenotypedVcfJobTest {
 
-	@Autowired
+    @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
     
     @Autowired

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -16,6 +16,20 @@
 
 package uk.ac.ebi.eva.pipeline.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,19 +48,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfWorkflowConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
+import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
+import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep;
-import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
-import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-import java.nio.file.Paths;
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Diego Poggioli
@@ -55,20 +65,14 @@ import static org.junit.Assert.*;
  */
 @IntegrationTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { JobOptions.class, GenotypedVcfJob.class, GenotypedVcfWorkflowConfiguration.class})
+@ContextConfiguration(classes = { JobOptions.class, GenotypedVcfJob.class, GenotypedVcfWorkflowConfiguration.class, JobLauncherTestUtils.class})
 public class GenotypedVcfJobWorkflowTest {
 
+    @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 
     @Autowired
     private JobOptions jobOptions;
-
-    @Autowired
-    private JobLauncher jobLauncher;
-
-    @Autowired
-    @Qualifier("genotypedJob")
-    public Job job;
 
     private String inputFileResouce;
     private String outputDir;
@@ -102,8 +106,8 @@ public class GenotypedVcfJobWorkflowTest {
 
         Set<String> parallelStepNamesExecuted = parallelStepsNameToStepExecution.keySet();
         Set<String> parallelStepNamesToCheck = new HashSet<>(Arrays.asList(
-                PopulationStatisticsJob.CALCULATE_STATISTICS,
-                PopulationStatisticsJob.LOAD_STATISTICS,
+                PopulationStatisticsFlow.CALCULATE_STATISTICS,
+                PopulationStatisticsFlow.LOAD_STATISTICS,
                 VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE,
                 VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION,
                 AnnotationLoaderStep.LOAD_VEP_ANNOTATION));
@@ -111,11 +115,11 @@ public class GenotypedVcfJobWorkflowTest {
         assertEquals(parallelStepNamesToCheck, parallelStepNamesExecuted);
 
         assertTrue(transformStep.getEndTime().before(loadStep.getStartTime()));
-        assertTrue(loadStep.getEndTime().before(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.CALCULATE_STATISTICS).getStartTime()));
+        assertTrue(loadStep.getEndTime().before(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.CALCULATE_STATISTICS).getStartTime()));
         assertTrue(loadStep.getEndTime().before(parallelStepsNameToStepExecution.get(VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE).getStartTime()));
 
-        assertTrue(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.CALCULATE_STATISTICS).getEndTime()
-                .before(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.LOAD_STATISTICS).getStartTime()));
+        assertTrue(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.CALCULATE_STATISTICS).getEndTime()
+                .before(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.LOAD_STATISTICS).getStartTime()));
         assertTrue(parallelStepsNameToStepExecution.get(VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE).getEndTime()
                 .before(parallelStepsNameToStepExecution.get(VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION).getStartTime()));
         assertTrue(parallelStepsNameToStepExecution.get(VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION).getEndTime()
@@ -127,7 +131,7 @@ public class GenotypedVcfJobWorkflowTest {
         initVariantConfigurationJob();
 
         jobOptions.getPipelineOptions().put(AnnotationFlow.SKIP_ANNOT, true);
-        jobOptions.getPipelineOptions().put(PopulationStatisticsJob.SKIP_STATS, true);
+        jobOptions.getPipelineOptions().put(PopulationStatisticsFlow.SKIP_STATS, true);
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
 
@@ -147,7 +151,7 @@ public class GenotypedVcfJobWorkflowTest {
     @Test
     public void statsStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(PopulationStatisticsJob.SKIP_STATS, true);
+        jobOptions.getPipelineOptions().put(PopulationStatisticsFlow.SKIP_STATS, true);
 
         jobOptions.getPipelineOptions().put("db.name", "diegoTest");
 
@@ -210,16 +214,16 @@ public class GenotypedVcfJobWorkflowTest {
 
         Set<String> parallelStepNamesExecuted = parallelStepsNameToStepExecution.keySet();
         Set<String> parallelStepNamesToCheck = new HashSet<>(Arrays.asList(
-                PopulationStatisticsJob.CALCULATE_STATISTICS,
-                PopulationStatisticsJob.LOAD_STATISTICS));
+        		PopulationStatisticsFlow.CALCULATE_STATISTICS,
+        		PopulationStatisticsFlow.LOAD_STATISTICS));
 
         assertEquals(parallelStepNamesToCheck, parallelStepNamesExecuted);
 
         assertTrue(transformStep.getEndTime().before(loadStep.getStartTime()));
-        assertTrue(loadStep.getEndTime().before(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.CALCULATE_STATISTICS).getStartTime()));
+        assertTrue(loadStep.getEndTime().before(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.CALCULATE_STATISTICS).getStartTime()));
 
-        assertTrue(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.CALCULATE_STATISTICS).getEndTime()
-                .before(parallelStepsNameToStepExecution.get(PopulationStatisticsJob.LOAD_STATISTICS).getStartTime()));
+        assertTrue(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.CALCULATE_STATISTICS).getEndTime()
+                .before(parallelStepsNameToStepExecution.get(PopulationStatisticsFlow.LOAD_STATISTICS).getStartTime()));
     }
 
     /**
@@ -230,9 +234,6 @@ public class GenotypedVcfJobWorkflowTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobLauncherTestUtils = new JobLauncherTestUtils();
-        jobLauncherTestUtils.setJob(job);
-        jobLauncherTestUtils.setJobLauncher(jobLauncher);
 
         inputFileResouce = jobOptions.getPipelineOptions().getString("input.vcf");
         outputDir = jobOptions.getPipelineOptions().getString("output.dir");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -38,6 +38,7 @@ import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfWorkflowConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep;
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -125,7 +126,7 @@ public class GenotypedVcfJobWorkflowTest {
     public void optionalStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
 
-        jobOptions.getPipelineOptions().put(AnnotationJob.SKIP_ANNOT, true);
+        jobOptions.getPipelineOptions().put(AnnotationFlow.SKIP_ANNOT, true);
         jobOptions.getPipelineOptions().put(PopulationStatisticsJob.SKIP_STATS, true);
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
@@ -188,7 +189,7 @@ public class GenotypedVcfJobWorkflowTest {
     @Test
     public void annotationStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(AnnotationJob.SKIP_ANNOT, true);
+        jobOptions.getPipelineOptions().put(AnnotationFlow.SKIP_ANNOT, true);
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -59,7 +59,6 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 public class PopulationStatisticsJobTest {
 
     private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
-    private static final String STATS_DB = "VariantStatsConfigurationTest_vl"; //this name should be the same of the dump DB in /dump
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
@@ -80,7 +79,6 @@ public class PopulationStatisticsJobTest {
         String input = SMALL_VCF_FILE;
 
         pipelineOptions.put("input.vcf", input);
-        variantOptions.put(VariantStorageManager.DB_NAME, STATS_DB);
 
         VariantSource source = new VariantSource(
                 input,
@@ -113,7 +111,7 @@ public class PopulationStatisticsJobTest {
 
         // The DB docs should have the field "st"
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();
-        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(STATS_DB, null);
+        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(jobOptions.getDbName(), null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(new QueryOptions());
         assertEquals(1, iterator.next().getSourceEntries().values().iterator().next().getCohortStats().size());
 
@@ -125,7 +123,7 @@ public class PopulationStatisticsJobTest {
     private void initStatsLoadStepFiles() throws IOException, InterruptedException {
         //and a valid variants load and stats create steps already completed
         String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
         String outputDir = pipelineOptions.getString("output.dir.statistics");
 
@@ -152,13 +150,14 @@ public class PopulationStatisticsJobTest {
     public void setUp() throws Exception {
         //re-initialize common config before each test
         jobOptions.loadArgs();
+        jobOptions.setDbName(getClass().getSimpleName());
         pipelineOptions = jobOptions.getPipelineOptions();
         variantOptions = jobOptions.getVariantOptions();
     }
 
     @After
     public void tearDown() throws Exception {
-        JobTestUtils.cleanDBs(STATS_DB);
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -125,7 +125,7 @@ public class PopulationStatisticsJobTest {
     private void initStatsLoadStepFiles() throws IOException, InterruptedException {
         //and a valid variants load and stats create steps already completed
         String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump);
+        restoreMongoDbFromDump(dump, getClass().getSimpleName());
 
         String outputDir = pipelineOptions.getString("output.dir.statistics");
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -75,6 +75,9 @@ public class PopulationStatisticsJobTest {
 
     @Test
     public void fullPopulationStatisticsJob() throws Exception {
+        String dump = PopulationStatisticsJobTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        JobTestUtils.restoreMongoDbFromDump(dump, jobOptions.getDbName());
+        
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
 
@@ -90,8 +93,8 @@ public class PopulationStatisticsJobTest {
 
         variantOptions.put(VARIANT_SOURCE, source);
 
-        statsFile = new File(Paths.get(pipelineOptions.getString("output.dir.statistics")).resolve(VariantStorageManager.buildFilename(source))
-                + ".variants.stats.json.gz");
+        statsFile = new File(Paths.get(pipelineOptions.getString("output.dir.statistics"))
+                .resolve(VariantStorageManager.buildFilename(source)) + ".variants.stats.json.gz");
         statsFile.delete();
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -33,7 +33,7 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.AnnotationLoaderStepConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.test.data.VepOutputContent;
@@ -53,7 +53,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
  * to run properly.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { AnnotationJob.class, AnnotationConfiguration.class, JobLauncherTestUtils.class})
+@ContextConfiguration(classes = { AnnotationJob.class, AnnotationLoaderStepConfiguration.class, JobLauncherTestUtils.class})
 public class AnnotationLoaderStepTest {
 
     @Autowired
@@ -66,7 +66,6 @@ public class AnnotationLoaderStepTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobOptions.setDbName(getClass().getSimpleName());
         mongoClient = new MongoClient();
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -76,7 +76,7 @@ public class AnnotationLoaderStepTest {
         DBObjectToVariantAnnotationConverter converter = new DBObjectToVariantAnnotationConverter();
 
         String dump = AnnotationLoaderStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump);
+        restoreMongoDbFromDump(dump, getClass().getSimpleName());
 
         String vepOutput = jobOptions.getVepOutput();
         makeGzipFile(VepOutputContent.vepOutputContent, vepOutput);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -61,13 +61,12 @@ public class AnnotationLoaderStepTest {
     @Autowired
     private JobOptions jobOptions;
 
-    private String dbName;
     private MongoClient mongoClient;
 
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        dbName = jobOptions.getDbName();
+        jobOptions.setDbName(getClass().getSimpleName());
         mongoClient = new MongoClient();
     }
 
@@ -75,8 +74,8 @@ public class AnnotationLoaderStepTest {
     public void shouldLoadAllAnnotations() throws Exception {
         DBObjectToVariantAnnotationConverter converter = new DBObjectToVariantAnnotationConverter();
 
-        String dump = AnnotationLoaderStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        String dump = AnnotationLoaderStepTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
         String vepOutput = jobOptions.getVepOutput();
         makeGzipFile(VepOutputContent.vepOutputContent, vepOutput);
@@ -87,7 +86,7 @@ public class AnnotationLoaderStepTest {
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         //check that documents have the annotation
-        DBCursor cursor = collection(dbName, jobOptions.getDbCollectionsVariantsName()).find();
+        DBCursor cursor = collection(jobOptions.getDbName(), jobOptions.getDbCollectionsVariantsName()).find();
 
         int cnt=0;
         int consequenceTypeCount = 0;
@@ -110,7 +109,7 @@ public class AnnotationLoaderStepTest {
      */
     @After
     public void tearDown() throws Exception {
-        JobTestUtils.cleanDBs(dbName);
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
         mongoClient.close();
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
+import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 import java.io.File;
@@ -94,7 +95,7 @@ public class PopulationStatisticsGeneratorStepTest {
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
 
         // When the execute method in variantsStatsCreate is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsJob.CALCULATE_STATISTICS);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.CALCULATE_STATISTICS);
 
         //Then variantsStatsCreate step should complete correctly
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
@@ -138,7 +139,7 @@ public class PopulationStatisticsGeneratorStepTest {
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
 
         // When the execute method in variantsStatsCreate is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsJob.CALCULATE_STATISTICS);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.CALCULATE_STATISTICS);
         assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -71,7 +71,7 @@ public class PopulationStatisticsGeneratorStepTest {
     public void statisticsGeneratorStepShouldCalculateStats() throws IOException, InterruptedException {
         //and a valid variants load step already completed
         String dump = PopulationStatisticsGeneratorStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump);
+        restoreMongoDbFromDump(dump, getClass().getSimpleName());
 
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -56,7 +56,6 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 public class PopulationStatisticsGeneratorStepTest {
 
     private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
-    private static final String STATS_DB = "VariantStatsConfigurationTest_vl"; //this name should be the same of the dump DB in /dump
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
@@ -70,14 +69,13 @@ public class PopulationStatisticsGeneratorStepTest {
     @Test
     public void statisticsGeneratorStepShouldCalculateStats() throws IOException, InterruptedException {
         //and a valid variants load step already completed
-        String dump = PopulationStatisticsGeneratorStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        String dump = PopulationStatisticsGeneratorStepTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
 
         pipelineOptions.put("input.vcf", input);
-        variantOptions.put(VariantStorageManager.DB_NAME, STATS_DB);
 
         VariantSource source = new VariantSource(
                 input,
@@ -121,7 +119,6 @@ public class PopulationStatisticsGeneratorStepTest {
         String input = SMALL_VCF_FILE;
 
         pipelineOptions.put("input.vcf", input);
-        variantOptions.put(VariantStorageManager.DB_NAME, STATS_DB);
 
         VariantSource source = new VariantSource(
                 input,
@@ -146,13 +143,14 @@ public class PopulationStatisticsGeneratorStepTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
+        jobOptions.setDbName(getClass().getSimpleName());
         pipelineOptions = jobOptions.getPipelineOptions();
         variantOptions = jobOptions.getVariantOptions();
     }
 
     @After
     public void tearDown() throws Exception {
-        JobTestUtils.cleanDBs(STATS_DB);
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -72,7 +72,7 @@ public class PopulationStatisticsLoaderStepTest {
 
         //and a valid variants load and stats create steps already completed
         String dump = PopulationStatisticsLoaderStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump);
+        restoreMongoDbFromDump(dump, getClass().getSimpleName());
 
         String outputDir = pipelineOptions.getString("output.dir.statistics");
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
+import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 import java.io.File;
@@ -94,7 +95,7 @@ public class PopulationStatisticsLoaderStepTest {
         FileUtils.copyFile(vcfFile, vcfFileToLoad);
 
         // When the execute method in variantsStatsLoad is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsJob.LOAD_STATISTICS);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.LOAD_STATISTICS);
 
         // Then variantsStatsLoad step should complete correctly
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
@@ -120,7 +121,7 @@ public class PopulationStatisticsLoaderStepTest {
         variantOptions.put(VariantStorageManager.DB_NAME, STATS_DB);
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
 
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsJob.LOAD_STATISTICS);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.LOAD_STATISTICS);
 
         assertEquals(input, pipelineOptions.getString("input.vcf"));
         assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -43,7 +43,6 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 public class PopulationStatisticsLoaderStepTest {
 
     private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
-    private static final String STATS_DB = "VariantStatsConfigurationTest_vl"; //this name should be the same of the dump DB in /dump
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
@@ -64,15 +63,12 @@ public class PopulationStatisticsLoaderStepTest {
         String input = PopulationStatisticsLoaderStepTest.class.getResource(SMALL_VCF_FILE).getFile();
         VariantSource source = new VariantSource(input, "1", "1", "studyName");
 
-        String dbName = STATS_DB;
-
         pipelineOptions.put("input.vcf", input);
-        variantOptions.put(VariantStorageManager.DB_NAME, dbName);
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
 
         //and a valid variants load and stats create steps already completed
-        String dump = PopulationStatisticsLoaderStepTest.class.getResource("/dump/").getFile();
-        restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        String dump = PopulationStatisticsLoaderStepTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
         String outputDir = pipelineOptions.getString("output.dir.statistics");
 
@@ -103,7 +99,7 @@ public class PopulationStatisticsLoaderStepTest {
 
         // The DB docs should have the field "st"
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();
-        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(dbName, null);
+        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(jobOptions.getDbName(), null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(new QueryOptions());
         assertEquals(1, iterator.next().getSourceEntries().values().iterator().next().getCohortStats().size());
 
@@ -118,7 +114,7 @@ public class PopulationStatisticsLoaderStepTest {
         VariantSource source = new VariantSource(input, "4", "1", "studyName");
 
         pipelineOptions.put("input.vcf", input);
-        variantOptions.put(VariantStorageManager.DB_NAME, STATS_DB);
+        variantOptions.put(VariantStorageManager.DB_NAME, jobOptions.getDbName());
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.LOAD_STATISTICS);
@@ -132,11 +128,12 @@ public class PopulationStatisticsLoaderStepTest {
         jobOptions.loadArgs();
         pipelineOptions = jobOptions.getPipelineOptions();
         variantOptions = jobOptions.getVariantOptions();
+        jobOptions.setDbName(getClass().getSimpleName());
     }
 
     @After
     public void tearDown() throws Exception {
-        JobTestUtils.cleanDBs(STATS_DB);
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -29,11 +29,8 @@ import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
 import org.springframework.batch.core.*;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
@@ -56,20 +53,14 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
  * Test for {@link VariantLoaderStep}
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {GenotypedVcfJob.class, JobOptions.class, GenotypedVcfConfiguration.class})
+@ContextConfiguration(classes = {GenotypedVcfJob.class, JobOptions.class, GenotypedVcfConfiguration.class, JobLauncherTestUtils.class})
 public class VariantLoaderStepTest {
+	
+    @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 
     @Autowired
     private JobOptions jobOptions;
-    @Autowired
-    private JobLauncher jobLauncher;
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    @Qualifier("genotypedJob")
-    public Job job;
 
     private String input;
     private String outputDir;
@@ -148,10 +139,6 @@ public class VariantLoaderStepTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobLauncherTestUtils = new JobLauncherTestUtils();
-        jobLauncherTestUtils.setJob(job);
-        jobLauncherTestUtils.setJobLauncher(jobLauncher);
-        jobLauncherTestUtils.setJobRepository(jobRepository);
 
         input = jobOptions.getPipelineOptions().getString("input.vcf");
         outputDir = jobOptions.getPipelineOptions().getString("output.dir");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -55,7 +55,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {GenotypedVcfJob.class, JobOptions.class, GenotypedVcfConfiguration.class, JobLauncherTestUtils.class})
 public class VariantLoaderStepTest {
-	
+
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
@@ -22,11 +22,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opencb.opencga.lib.common.Config;
 import org.springframework.batch.core.*;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
@@ -54,21 +51,14 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
  * FILE_WRONG_NO_ALT should be renamed because the alt allele is not missing but is the same as the reference
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {GenotypedVcfJob.class, JobOptions.class, GenotypedVcfConfiguration.class})
+@ContextConfiguration(classes = {GenotypedVcfJob.class, JobOptions.class, GenotypedVcfConfiguration.class, JobLauncherTestUtils.class})
 public class VariantNormalizerStepTest extends CommonJobStepInitialization {
 
+    @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
 
     @Autowired
     private JobOptions jobOptions;
-    @Autowired
-    private JobLauncher jobLauncher;
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    @Qualifier("genotypedJob")
-    public Job job;
 
     private String input;
     private String outputDir;
@@ -131,10 +121,6 @@ public class VariantNormalizerStepTest extends CommonJobStepInitialization {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobLauncherTestUtils = new JobLauncherTestUtils();
-        jobLauncherTestUtils.setJob(job);
-        jobLauncherTestUtils.setJobLauncher(jobLauncher);
-        jobLauncherTestUtils.setJobRepository(jobRepository);
 
         input = jobOptions.getPipelineOptions().getString("input.vcf");
         outputDir = jobOptions.getPipelineOptions().getString("output.dir");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStepTest.java
@@ -31,6 +31,7 @@ import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJobTest;
+import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 import java.io.File;
@@ -72,7 +73,7 @@ public class VepAnnotationGeneratorStepTest {
         TestCase.assertFalse(vepOutputFile.exists());  // ensure the annot file doesn't exist from previous executions
 
         // When the execute method in variantsAnnotCreate is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(AnnotationJob.GENERATE_VEP_ANNOTATION);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(AnnotationFlow.GENERATE_VEP_ANNOTATION);
 
         //Then variantsAnnotCreate step should complete correctly
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
@@ -17,6 +17,7 @@ package uk.ac.ebi.eva.pipeline.jobs.steps;
 
 
 import junit.framework.TestCase;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +48,6 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.readFirstLine;
 @ContextConfiguration(classes = { AnnotationJob.class, AnnotationConfiguration.class, JobLauncherTestUtils.class})
 public class VepInputGeneratorStepTest {
 
-    private static final String VARIANTS_ANNOT_GENERATE_VEP_INPUT_DB_NAME = "VariantStatsConfigurationTest_vl";
-
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
     @Autowired
@@ -57,12 +56,18 @@ public class VepInputGeneratorStepTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
+        jobOptions.setDbName(getClass().getSimpleName());
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        JobTestUtils.cleanDBs(jobOptions.getDbName());
     }
 
     @Test
     public void shouldGenerateVepInput() throws Exception {
-        String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        JobTestUtils.restoreMongoDbFromDump(dump, getClass().getSimpleName());
+        String dump = PopulationStatisticsJobTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
+        JobTestUtils.restoreMongoDbFromDump(dump, jobOptions.getDbName());
         File vepInputFile = new File(jobOptions.getVepInput());
 
         if(vepInputFile.exists())
@@ -77,6 +82,5 @@ public class VepInputGeneratorStepTest {
 
         Assert.assertTrue(vepInputFile.exists());
         TestCase.assertEquals("20\t60343\t60343\tG/A\t+", readFirstLine(vepInputFile));
-        JobTestUtils.cleanDBs(VARIANTS_ANNOT_GENERATE_VEP_INPUT_DB_NAME);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
@@ -29,7 +29,7 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.VepInputGeneratorStepConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJobTest;
@@ -45,7 +45,7 @@ import static uk.ac.ebi.eva.test.utils.JobTestUtils.readFirstLine;
  * Test {@link VepInputGeneratorStep}
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { AnnotationJob.class, AnnotationConfiguration.class, JobLauncherTestUtils.class})
+@ContextConfiguration(classes = { AnnotationJob.class, VepInputGeneratorStepConfiguration.class, JobLauncherTestUtils.class})
 public class VepInputGeneratorStepTest {
 
     @Autowired
@@ -56,7 +56,6 @@ public class VepInputGeneratorStepTest {
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
-        jobOptions.setDbName(getClass().getSimpleName());
     }
     
     @After

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
@@ -62,7 +62,7 @@ public class VepInputGeneratorStepTest {
     @Test
     public void shouldGenerateVepInput() throws Exception {
         String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
-        JobTestUtils.restoreMongoDbFromDump(dump);
+        JobTestUtils.restoreMongoDbFromDump(dump, getClass().getSimpleName());
         File vepInputFile = new File(jobOptions.getVepInput());
 
         if(vepInputFile.exists())

--- a/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
+++ b/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
@@ -129,7 +129,7 @@ public class JobTestUtils {
     	
         logger.info("restoring DB from " + dumpLocation + " into database " + databaseName);
 
-        Process exec = Runtime.getRuntime().exec(String.format("mongorestore -d {} {}", databaseName, dumpLocation));
+        Process exec = Runtime.getRuntime().exec(String.format("mongorestore -d %s %s", databaseName, dumpLocation));
         exec.waitFor();
         String line;
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(exec.getInputStream()));

--- a/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
+++ b/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
@@ -123,10 +123,13 @@ public class JobTestUtils {
         }
     }
 
-    public static void restoreMongoDbFromDump(String dumpLocation) throws IOException, InterruptedException {
-        logger.info("restoring DB from " + dumpLocation);
+    public static void restoreMongoDbFromDump(String dumpLocation, String databaseName) throws IOException, InterruptedException {
+    	assert(dumpLocation != null && !dumpLocation.isEmpty());
+    	assert(databaseName != null && !databaseName.isEmpty());
+    	
+        logger.info("restoring DB from " + dumpLocation + " into database " + databaseName);
 
-        Process exec = Runtime.getRuntime().exec("mongorestore " + dumpLocation);
+        Process exec = Runtime.getRuntime().exec(String.format("mongorestore -d {} {}", databaseName, dumpLocation));
         exec.waitFor();
         String line;
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(exec.getInputStream()));

--- a/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
+++ b/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
@@ -124,8 +124,8 @@ public class JobTestUtils {
     }
 
     public static void restoreMongoDbFromDump(String dumpLocation, String databaseName) throws IOException, InterruptedException {
-    	assert(dumpLocation != null && !dumpLocation.isEmpty());
-    	assert(databaseName != null && !databaseName.isEmpty());
+        assert(dumpLocation != null && !dumpLocation.isEmpty());
+        assert(databaseName != null && !databaseName.isEmpty());
     	
         logger.info("restoring DB from " + dumpLocation + " into database " + databaseName);
 

--- a/src/test/resources/annotation-job.properties
+++ b/src/test/resources/annotation-job.properties
@@ -1,0 +1,32 @@
+input.vcf=/small20.vcf.gz
+input.vcf.id=1
+input.vcf.aggregation=NONE
+input.study.type=COLLECTION
+input.study.name=ELOAD-58
+input.study.id=annotation-job
+input.pedigree=
+input.gtf=
+input.fasta=
+
+output.dir=
+output.dir.annotation=/tmp/
+output.dir.statistics=/tmp/
+
+app.opencga.path=
+app.vep.path=/tmp/mockvep.pl
+
+# VEP
+app.vep.cache.path=
+app.vep.cache.version=
+app.vep.cache.species=
+app.vep.num-forks=
+
+
+# Repeat steps
+# true: The already COMPLETEd steps will be rerun. This is restarting the job from the beginning
+# false(default): if the job was aborted and is relaunched, COMPLETEd steps will NOT be done again
+config.restartability.allow=false
+
+config.db.read-preference=primary
+db.name=AnnotationJobTest
+db.collections.features.name=features

--- a/src/test/resources/annotation-job.properties
+++ b/src/test/resources/annotation-job.properties
@@ -28,5 +28,7 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=AnnotationJobTest
+
 db.collections.features.name=features
+db.collections.stats.name=populationStatistics
+db.name=AnnotationJobTest

--- a/src/test/resources/annotation-loader-step.properties
+++ b/src/test/resources/annotation-loader-step.properties
@@ -1,0 +1,32 @@
+input.vcf=/small20.vcf.gz
+input.vcf.id=1
+input.vcf.aggregation=NONE
+input.study.type=COLLECTION
+input.study.name=ELOAD-58
+input.study.id=annotation-loader-step
+input.pedigree=
+input.gtf=
+input.fasta=
+
+output.dir=
+output.dir.annotation=/tmp/
+output.dir.statistics=/tmp/
+
+app.opencga.path=
+app.vep.path=/tmp/mockvep.pl
+
+# VEP
+app.vep.cache.path=
+app.vep.cache.version=
+app.vep.cache.species=
+app.vep.num-forks=
+
+
+# Repeat steps
+# true: The already COMPLETEd steps will be rerun. This is restarting the job from the beginning
+# false(default): if the job was aborted and is relaunched, COMPLETEd steps will NOT be done again
+config.restartability.allow=false
+
+config.db.read-preference=primary
+db.name=AnnotationLoaderStepTest
+db.collections.features.name=features

--- a/src/test/resources/annotation-loader-step.properties
+++ b/src/test/resources/annotation-loader-step.properties
@@ -28,5 +28,7 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=AnnotationLoaderStepTest
+
 db.collections.features.name=features
+db.collections.stats.name=populationStatistics
+db.name=AnnotationLoaderStepTest

--- a/src/test/resources/annotation.properties
+++ b/src/test/resources/annotation.properties
@@ -28,6 +28,6 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=VariantStatsConfigurationTest_vl
+db.name=VariantAnnotation
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics

--- a/src/test/resources/variantAggregatedConfiguration.properties
+++ b/src/test/resources/variantAggregatedConfiguration.properties
@@ -1,9 +1,9 @@
 input.vcf=/aggregated.vcf.gz
-input.vcf.id=5
+input.vcf.id=1
 input.vcf.aggregation=BASIC
 input.study.type=COLLECTION
 input.study.name=studyName
-input.study.id=7
+input.study.id=aggregated-job
 input.pedigree=
 input.gtf=
 input.fasta=/path/to/file.fa
@@ -30,6 +30,6 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=variant-aggregated-configuration-testdb
+db.name=AggregatedJobTest
 
 annotation.skip=true

--- a/src/test/resources/variantConfiguration.properties
+++ b/src/test/resources/variantConfiguration.properties
@@ -1,9 +1,9 @@
 input.vcf=/small20.vcf.gz
-input.vcf.id=5
+input.vcf.id=1
 input.vcf.aggregation=NONE
 input.study.type=COLLECTION
 input.study.name=studyName
-input.study.id=7
+input.study.id=genotyped-job
 input.pedigree=
 input.gtf=
 input.fasta=/path/to/file.fa
@@ -30,4 +30,4 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=variant-configuration-testdb
+db.name=GenotypedVcfJobTest

--- a/src/test/resources/variantConfigurationWorkflow.properties
+++ b/src/test/resources/variantConfigurationWorkflow.properties
@@ -1,9 +1,9 @@
 input.vcf=/small20.vcf.gz
-input.vcf.id=5
+input.vcf.id=1
 input.vcf.aggregation=NONE
 input.study.type=COLLECTION
 input.study.name=studyName
-input.study.id=7
+input.study.id=genotyped-job-workflow
 input.pedigree=
 input.gtf=
 input.fasta=/path/to/file.fa
@@ -30,4 +30,4 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=variant-configuration-workflow-testdb
+db.name=GenotypedVcfWorkflowTest

--- a/src/test/resources/vep-input-generator-step.properties
+++ b/src/test/resources/vep-input-generator-step.properties
@@ -1,0 +1,32 @@
+input.vcf=/small20.vcf.gz
+input.vcf.id=1
+input.vcf.aggregation=NONE
+input.study.type=COLLECTION
+input.study.name=ELOAD-58
+input.study.id=vep-input-generator-step
+input.pedigree=
+input.gtf=
+input.fasta=
+
+output.dir=
+output.dir.annotation=/tmp/
+output.dir.statistics=/tmp/
+
+app.opencga.path=
+app.vep.path=/tmp/mockvep.pl
+
+# VEP
+app.vep.cache.path=
+app.vep.cache.version=
+app.vep.cache.species=
+app.vep.num-forks=
+
+
+# Repeat steps
+# true: The already COMPLETEd steps will be rerun. This is restarting the job from the beginning
+# false(default): if the job was aborted and is relaunched, COMPLETEd steps will NOT be done again
+config.restartability.allow=false
+
+config.db.read-preference=primary
+db.name=AnnotationLoaderStepTest
+db.collections.features.name=features

--- a/src/test/resources/vep-input-generator-step.properties
+++ b/src/test/resources/vep-input-generator-step.properties
@@ -28,5 +28,6 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=AnnotationLoaderStepTest
+db.name=VepInputGeneratorStepTest
 db.collections.features.name=features
+db.collections.stats.name=populationStatistics


### PR DESCRIPTION
In order to reduce the configuration required, some test classes share the database name, input/output files, etc. There are 2 implications:

* Some test classes can't be run by themselves, because they depend on files generated by others.
* They can't run in parallel, because they are writing to the same database at the same time.

This PR makes every class use a different database name, and not to depend on files that were generated as output from another one. Every test class has been tested independently from the others to guarantee these dependencies do not apply. In order to run the tests this way, please use the following commands:

```
for i in `find src/test/java/uk/ac/ebi/eva/pipeline/io -name "*.java" | rev | cut -d"/" -f1 | rev | cut -d"." -f1` ; do mvn test -Dtest=$i ; done
```

and

```
for i in `find src/test/java/uk/ac/ebi/eva/pipeline/jobs -name "*.java" | rev | cut -d"/" -f1 | rev | cut -d"." -f1` ; do mvn test -Dtest=$i ; done
```