### PR TITLE
Using org.junit package

### DIFF
--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/AnnotationLineMapperTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/AnnotationLineMapperTest.java
@@ -15,11 +15,12 @@
  */
 package uk.ac.ebi.eva.pipeline.io.mappers;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
-import uk.ac.ebi.eva.test.data.VepOutputContent;
 
-import static junit.framework.TestCase.assertNotNull;
+import uk.ac.ebi.eva.test.data.VepOutputContent;
 
 /**
  * {@link AnnotationLineMapper}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/AnnotationFlatFileReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/AnnotationFlatFileReaderTest.java
@@ -15,19 +15,20 @@
  */
 package uk.ac.ebi.eva.pipeline.io.readers;
 
-import org.junit.Test;
-import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.file.FlatFileParseException;
-import org.springframework.batch.test.MetaDataInstanceFactory;
-import uk.ac.ebi.eva.test.utils.JobTestUtils;
-import uk.ac.ebi.eva.test.data.VepOutputContent;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.zip.GZIPInputStream;
 
-import static junit.framework.TestCase.assertEquals;
+import org.junit.Test;
+import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.file.FlatFileParseException;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+
+import uk.ac.ebi.eva.test.data.VepOutputContent;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 /**
  * {@link AnnotationFlatFileReader}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/GeneReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/GeneReaderTest.java
@@ -15,16 +15,19 @@
  */
 package uk.ac.ebi.eva.pipeline.io.readers;
 
-import org.junit.Test;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.test.MetaDataInstanceFactory;
-import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
-import uk.ac.ebi.eva.test.data.GtfStaticTestData;
-import uk.ac.ebi.eva.test.utils.JobTestUtils;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.zip.GZIPInputStream;
-import static junit.framework.TestCase.assertEquals;
+
+import org.junit.Test;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+
+import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
+import uk.ac.ebi.eva.test.data.GtfStaticTestData;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 /**
  * {@link GeneReader}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -15,9 +15,12 @@
  */
 package uk.ac.ebi.eva.pipeline.io.readers;
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,16 +32,16 @@ import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.IOException;
-import java.net.UnknownHostException;
-
-import static junit.framework.TestCase.*;
 
 /**
  * {@link NonAnnotatedVariantsMongoReader}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -16,10 +16,13 @@
 package uk.ac.ebi.eva.pipeline.io.writers;
 
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,18 +30,18 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.DatabaseInitializationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.test.data.GtfStaticTestData;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
 
 /**
  * {@link GeneWriter}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -15,9 +15,16 @@
  */
 package uk.ac.ebi.eva.pipeline.io.writers;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,10 +102,10 @@ public class VepAnnotationMongoWriterTest {
         while (cursor.hasNext()) {
             cnt++;
             VariantAnnotation annot = converter.convertToDataModelType((DBObject)cursor.next().get("annot"));
-            assertTrue(annot.getConsequenceTypes() != null);
+            assertNotNull(annot.getConsequenceTypes());
             consequenceTypeCount += annot.getConsequenceTypes().size();
         }
-        assertTrue(cnt>0);
+        assertTrue(cnt > 0);
         assertEquals(annotations.size(), consequenceTypeCount);
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -15,24 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs;
 
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.opencb.biodata.models.variant.VariantSource;
-import org.opencb.datastore.core.QueryOptions;
-import org.opencb.opencga.lib.common.Config;
-import org.opencb.opencga.storage.core.StorageManagerFactory;
-import org.opencb.opencga.storage.core.variant.VariantStorageManager;
-import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
-import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
-import org.springframework.batch.core.*;
-import org.springframework.batch.test.JobLauncherTestUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
-import uk.ac.ebi.eva.pipeline.configuration.VariantAggregatedConfig;
-import uk.ac.ebi.eva.test.utils.JobTestUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.cleanDBs;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
 
 import java.io.FileInputStream;
 import java.net.UnknownHostException;
@@ -41,10 +28,35 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.*;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.cleanDBs;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opencb.biodata.models.variant.VariantSource;
+import org.opencb.datastore.core.QueryOptions;
+import org.opencb.opencga.lib.common.Config;
+import org.opencb.opencga.storage.core.StorageManagerFactory;
+import org.opencb.opencga.storage.core.variant.VariantStorageManager;
+import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
+import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.VariantAggregatedConfig;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 /**
  * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -16,12 +16,21 @@
 
 package uk.ac.ebi.eva.pipeline.jobs;
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep.LOAD_VEP_ANNOTATION;
+import static uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION;
+import static uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,20 +45,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationJobConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
-import static uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep.GENERATE_VEP_ANNOTATION;
-import static uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE;
-import static uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep.LOAD_VEP_ANNOTATION;
 
 /**
  * @author Diego Poggioli
@@ -127,7 +131,7 @@ public class AnnotationJobTest {
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
-        Assert.assertEquals(1, jobExecution.getStepExecutions().size());
+        assertEquals(1, jobExecution.getStepExecutions().size());
         StepExecution findVariantsToAnnotateStep = new ArrayList<>(jobExecution.getStepExecutions()).get(0);
 
         assertEquals(FIND_VARIANTS_TO_ANNOTATE, findVariantsToAnnotateStep.getStepName());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -16,6 +16,24 @@
 
 package uk.ac.ebi.eva.pipeline.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,31 +47,23 @@ import org.opencb.opencga.storage.core.StorageManagerFactory;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
-import org.springframework.batch.core.*;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
-
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.*;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.*;
 
 /**
  * @author Diego Poggioli

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -15,6 +15,16 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -35,19 +45,10 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 
 /**
  * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -15,10 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.makeGzipFile;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,16 +34,17 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationLoaderStepConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.test.data.VepOutputContent;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.makeGzipFile;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 
 
 /**
@@ -100,7 +102,7 @@ public class AnnotationLoaderStepTest {
         }
 
         assertEquals(300, cnt);
-        assertTrue("Annotations not found", consequenceTypeCount>0);
+        assertTrue("Annotations not found", consequenceTypeCount > 0);
     }
 
     /**

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
@@ -15,10 +15,8 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBCollection;
-import com.mongodb.DuplicateKeyException;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,12 +28,17 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DuplicateKeyException;
+import com.mongodb.MongoClient;
+
 import uk.ac.ebi.eva.pipeline.configuration.DatabaseInitializationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.DatabaseInitializationJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
-import static junit.framework.TestCase.assertEquals;
 
 /**
  * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStepTest.java
@@ -15,7 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.stream.Collectors;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,13 +35,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.common.collect.Sets;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
-
-import java.util.stream.Collectors;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Diego Poggioli

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -15,6 +15,16 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,21 +40,12 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
 import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 
 /**
  * @author Diego Poggioli

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -15,6 +15,15 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
+import static org.junit.Assert.assertEquals;
+import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.zip.GZIPInputStream;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -28,24 +37,22 @@ import org.opencb.opencga.storage.core.StorageManagerFactory;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
-import org.springframework.batch.core.*;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.zip.GZIPInputStream;
-
-import static junit.framework.TestCase.assertEquals;
-import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
 
 /**
  * @author Diego Poggioli

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
@@ -15,32 +15,38 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opencb.opencga.lib.common.Config;
-import org.springframework.batch.core.*;
-import org.springframework.batch.test.JobLauncherTestUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
-import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
-import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
-import uk.ac.ebi.eva.test.utils.JobTestUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Paths;
 import java.util.zip.GZIPInputStream;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opencb.opencga.lib.common.Config;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
+import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 /**
  * @author Diego Poggioli

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStepTest.java
@@ -15,7 +15,15 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.makeGzipFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.zip.GZIPInputStream;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,19 +35,13 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJobTest;
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.zip.GZIPInputStream;
-
-import static junit.framework.TestCase.assertEquals;
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.makeGzipFile;
 
 /**
  * @author Diego Poggioli
@@ -70,7 +72,7 @@ public class VepAnnotationGeneratorStepTest {
         jobOptions.setVepOutput(vepOutputFile.getAbsolutePath());
 
         vepOutputFile.delete();
-        TestCase.assertFalse(vepOutputFile.exists());  // ensure the annot file doesn't exist from previous executions
+        assertFalse(vepOutputFile.exists());  // ensure the annot file doesn't exist from previous executions
 
         // When the execute method in variantsAnnotCreate is executed
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(AnnotationFlow.GENERATE_VEP_ANNOTATION);
@@ -80,7 +82,7 @@ public class VepAnnotationGeneratorStepTest {
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         // And VEP output should exist and annotations should be in the file
-        TestCase.assertTrue(vepOutputFile.exists());
+        assertTrue(vepOutputFile.exists());
         Assert.assertEquals(537, JobTestUtils.getLines(new GZIPInputStream(new FileInputStream(vepOutputFile))));
         vepOutputFile.delete();
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStepTest.java
@@ -15,10 +15,14 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.readFirstLine;
 
-import junit.framework.TestCase;
+import java.io.File;
+
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,15 +33,12 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.VepInputGeneratorStepConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJobTest;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-
-import static uk.ac.ebi.eva.test.utils.JobTestUtils.readFirstLine;
 
 /**
  * @author Diego Poggioli
@@ -72,14 +73,14 @@ public class VepInputGeneratorStepTest {
         if(vepInputFile.exists())
             vepInputFile.delete();
 
-        Assert.assertFalse(vepInputFile.exists());
+        assertFalse(vepInputFile.exists());
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(VepInputGeneratorStep.FIND_VARIANTS_TO_ANNOTATE);
 
-        Assert.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        Assert.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
-        Assert.assertTrue(vepInputFile.exists());
-        TestCase.assertEquals("20\t60343\t60343\tG/A\t+", readFirstLine(vepInputFile));
+        assertTrue(vepInputFile.exists());
+        assertEquals("20\t60343\t60343\tG/A\t+", readFirstLine(vepInputFile));
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/processor/GeneFilterProcessorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/processor/GeneFilterProcessorTest.java
@@ -15,18 +15,19 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps.processor;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
 import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.test.MetaDataInstanceFactory;
+
 import uk.ac.ebi.eva.pipeline.io.readers.GeneReader;
 import uk.ac.ebi.eva.pipeline.jobs.steps.processors.GeneFilterProcessor;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.test.data.GtfStaticTestData;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
-
-import java.io.File;
-
-import static junit.framework.TestCase.assertEquals;
 
 /**
  * {@link GeneFilterProcessor}


### PR DESCRIPTION
Package `junit.framework` is deprecated but still used across a big part of our code. This PR replaces its occurrences with `org.junit`.