### PR TITLE
EVA-519 Job parameters names into constants

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -26,11 +26,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
-import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
+
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
-import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,6 +36,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Properties;
+import javax.annotation.PostConstruct;
 
 /**
  *
@@ -50,33 +49,28 @@ import java.util.Properties;
 @Component
 public class JobOptions {
     private static final Logger logger = LoggerFactory.getLogger(JobOptions.class);
-    private static final String DB_COLLECTIONS_FEATURES_NAME = "db.collections.features.name";
-    private static final String DB_COLLECTIONS_VARIANTS_NAME = "db.collections.variants.name";
-    private static final String DB_COLLECTIONS_STATS_NAME = "db.collections.stats.name";
-    private static final String VEP_INPUT = "vep.input";
-    private static final String DB_NAME = "db.name";
-    private static final String VEP_OUTPUT = "vep.output";
-    private static final String APP_VEP_PATH = "app.vep.path";
-    public static final String OUTPUT_DIR = "output.dir";
+
+    public static final String VEP_INPUT = "vep.input";
+    public static final String VEP_OUTPUT = "vep.output";
 
     // Input
-    @Value("${input.vcf}") private String input;
-    @Value("${input.vcf.id}") private String fileId;
-    @Value("${input.vcf.aggregation}") private String aggregated;
-    @Value("${input.study.type}") private String studyType;
-    @Value("${input.study.name}") private String studyName;
-    @Value("${input.study.id}") private String studyId;
-    @Value("${input.pedigree:}") private String pedigree;
-    @Value("${input.gtf}") private String gtf;
+    @Value("${" + JobParametersNames.INPUT_VCF + "}") private String input;
+    @Value("${" + JobParametersNames.INPUT_VCF_ID + "}") private String fileId;
+    @Value("${" + JobParametersNames.INPUT_VCF_AGGREGATION + "}") private String aggregated;
+    @Value("${" + JobParametersNames.INPUT_STUDY_TYPE + "}") private String studyType;
+    @Value("${" + JobParametersNames.INPUT_STUDY_NAME + "}") private String studyName;
+    @Value("${" + JobParametersNames.INPUT_STUDY_ID + "}") private String studyId;
+    @Value("${" + JobParametersNames.INPUT_PEDIGREE + ":}") private String pedigree;
+    @Value("${" + JobParametersNames.INPUT_GTF + "}") private String gtf;
 
     // Output
-    @Value("${"+OUTPUT_DIR+"}") private String outputDir;
-    @Value("${output.dir.annotation}") private String outputDirAnnotation;
-    @Value("${output.dir.statistics}") private String outputDirStatistics;
+    @Value("${" + JobParametersNames.OUTPUT_DIR + "}") private String outputDir;
+    @Value("${" + JobParametersNames.OUTPUT_DIR_ANNOTATION + "}") private String outputDirAnnotation;
+    @Value("${" + JobParametersNames.OUTPUT_DIR_STATISTICS + "}") private String outputDirStatistics;
 
-    @Value("${statistics.overwrite:false}") private boolean overwriteStats;
+    @Value("${" + JobParametersNames.STATISTICS_OVERWRITE + ":false}") private boolean overwriteStats;
 
-    @Value("${app.opencga.path}") private String opencgaAppHome;
+    @Value("${" + JobParametersNames.APP_OPENCGA_PATH + "}") private String opencgaAppHome;
 
     //// OpenCGA options with default values (non-customizable)
     private String compressExtension = ".gz";
@@ -84,35 +78,33 @@ public class JobOptions {
     private VariantStorageManager.IncludeSrc includeSourceLine = VariantStorageManager.IncludeSrc.FIRST_8_COLUMNS;
 
     /// DB connection (most parameters read from OpenCGA "conf" folder)
-    @Value("${config.db.hosts:#{null}}") private String dbHosts;
-    @Value("${config.db.authentication-db:#{null}}") private String dbAuthenticationDb;
-    @Value("${config.db.user:#{null}}") private String dbUser;
-    @Value("${config.db.password:#{null}}") private String dbPassword;
-    @Value("${"+DB_NAME+":#{null}}") private String dbName;
-    @Value("${"+DB_COLLECTIONS_VARIANTS_NAME+":#{null}}") private String dbCollectionVariantsName;
-    @Value("${db.collections.files.name:#{null}}") private String dbCollectionFilesName;
-    @Value("${"+DB_COLLECTIONS_FEATURES_NAME+"}") private String dbCollectionGenesName;
-    @Value("${"+DB_COLLECTIONS_STATS_NAME+"}") private String dbCollectionStatsName;
-    @Value("${config.db.read-preference}") private String readPreference;
+    @Value("${" + JobParametersNames.CONFIG_DB_HOSTS + ":#{null}}") private String dbHosts;
+    @Value("${" + JobParametersNames.CONFIG_DB_AUTHENTICATIONDB + ":#{null}}") private String dbAuthenticationDb;
+    @Value("${" + JobParametersNames.CONFIG_DB_USER + ":#{null}}") private String dbUser;
+    @Value("${" + JobParametersNames.CONFIG_DB_PASSWORD + ":#{null}}") private String dbPassword;
+    @Value("${" + JobParametersNames.DB_NAME + ":#{null}}") private String dbName;
+    @Value("${" + JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME + ":#{null}}") private String dbCollectionVariantsName;
+    @Value("${" + JobParametersNames.DB_COLLECTIONS_FILES_NAME + ":#{null}}") private String dbCollectionFilesName;
+    @Value("${" + JobParametersNames.DB_COLLECTIONS_FEATURES_NAME +"}") private String dbCollectionGenesName;
+    @Value("${" + JobParametersNames.DB_COLLECTIONS_STATS_NAME + "}") private String dbCollectionStatsName;
+    @Value("${" + JobParametersNames.CONFIG_DB_READ_PREFERENCE + "}") private String readPreference;
 
     // Skip steps
-    @Value("${annotation.skip:false}") private boolean skipAnnot;
-    @Value("${statistics.skip:false}") private boolean skipStats;
+    @Value("${" + JobParametersNames.ANNOTATION_SKIP + ":false}") private boolean skipAnnot;
+    @Value("${" + JobParametersNames.STATISTICS_SKIP + ":false}") private boolean skipStats;
 
     //VEP
-    @Value("${"+APP_VEP_PATH+"}") private String vepPath;
-    @Value("${app.vep.cache.path}") private String vepCacheDirectory;
-    @Value("${app.vep.cache.version}") private String vepCacheVersion;
-    @Value("${app.vep.cache.species}") private String vepSpecies;
-    @Value("${input.fasta}") private String vepFasta;
-    @Value("${app.vep.num-forks}") private String vepNumForks;
+    @Value("${" + JobParametersNames.APP_VEP_PATH +"}") private String vepPath;
+    @Value("${" + JobParametersNames.APP_VEP_CACHE_PATH + "}") private String vepCacheDirectory;
+    @Value("${" + JobParametersNames.APP_VEP_CACHE_VERSION + "}") private String vepCacheVersion;
+    @Value("${" + JobParametersNames.APP_VEP_CACHE_SPECIES + "}") private String vepSpecies;
+    @Value("${" + JobParametersNames.INPUT_FASTA + "}") private String vepFasta;
+    @Value("${" + JobParametersNames.APP_VEP_NUMFORKS + "}") private String vepNumForks;
 
-    @Value("${config.restartability.allow:false}") private boolean allowStartIfComplete;
+    @Value("${" + JobParametersNames.CONFIG_RESTARTABILITY_ALLOW + ":false}") private boolean allowStartIfComplete;
 
     private ObjectMap variantOptions  = new ObjectMap();
     private ObjectMap pipelineOptions  = new ObjectMap();
-    private File vepInput;
-    private File appVepPath;
 
     @PostConstruct
     public void loadArgs() throws IOException {
@@ -196,36 +188,36 @@ public class JobOptions {
     }
 
     private void loadPipelineOptions() {
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
         pipelineOptions.put("compressExtension", compressExtension);
-        pipelineOptions.put("output.dir", outputDir);
-        pipelineOptions.put("output.dir.statistics", outputDirStatistics);
-        pipelineOptions.put("input.pedigree", pedigree);
-        pipelineOptions.put("input.gtf", gtf);
-        pipelineOptions.put(DB_NAME, dbName);
-        pipelineOptions.put(DB_COLLECTIONS_VARIANTS_NAME, dbCollectionVariantsName);
-        pipelineOptions.put("db.collections.files.name", dbCollectionFilesName);
-        pipelineOptions.put(DB_COLLECTIONS_FEATURES_NAME, dbCollectionGenesName);
-        pipelineOptions.put(DB_COLLECTIONS_STATS_NAME, dbCollectionStatsName);
-        pipelineOptions.put("config.db.hosts", dbHosts);
-        pipelineOptions.put("config.db.authentication-db", dbAuthenticationDb);
-        pipelineOptions.put("config.db.user", dbUser);
-        pipelineOptions.put("config.db.password", dbPassword);
-        pipelineOptions.put("config.db.read-preference", readPreference);
-        pipelineOptions.put(AnnotationFlow.SKIP_ANNOT, skipAnnot);
-        pipelineOptions.put(PopulationStatisticsFlow.SKIP_STATS, skipStats);
+        pipelineOptions.put(JobParametersNames.OUTPUT_DIR, outputDir);
+        pipelineOptions.put(JobParametersNames.OUTPUT_DIR_STATISTICS, outputDirStatistics);
+        pipelineOptions.put(JobParametersNames.INPUT_PEDIGREE, pedigree);
+        pipelineOptions.put(JobParametersNames.INPUT_GTF, gtf);
+        pipelineOptions.put(JobParametersNames.DB_NAME, dbName);
+        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, dbCollectionVariantsName);
+        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FILES_NAME, dbCollectionFilesName);
+        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME, dbCollectionGenesName);
+        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_STATS_NAME, dbCollectionStatsName);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_HOSTS, dbHosts);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB, dbAuthenticationDb);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_USER, dbUser);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_PASSWORD, dbPassword);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_READ_PREFERENCE, readPreference);
+        pipelineOptions.put(JobParametersNames.ANNOTATION_SKIP, skipAnnot);
+        pipelineOptions.put(JobParametersNames.STATISTICS_SKIP, skipStats);
 
         String annotationFilesPrefix = studyId + "_" + fileId;
         pipelineOptions.put(VEP_INPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_variants_to_annotate.tsv").toString());
         pipelineOptions.put(VEP_OUTPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_vep_annotation.tsv.gz").toString());
 
-        pipelineOptions.put(APP_VEP_PATH, vepPath);
-        pipelineOptions.put("app.vep.cache.path", vepCacheDirectory);
-        pipelineOptions.put("app.vep.cache.version", vepCacheVersion);
-        pipelineOptions.put("app.vep.cache.species", vepSpecies);
-        pipelineOptions.put("input.fasta", vepFasta);
-        pipelineOptions.put("app.vep.num-forks", vepNumForks);
-        pipelineOptions.put("config.restartability.allow", allowStartIfComplete);
+        pipelineOptions.put(JobParametersNames.APP_VEP_PATH, vepPath);
+        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_PATH, vepCacheDirectory);
+        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_VERSION, vepCacheVersion);
+        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_SPECIES, vepSpecies);
+        pipelineOptions.put(JobParametersNames.INPUT_FASTA, vepFasta);
+        pipelineOptions.put(JobParametersNames.APP_VEP_NUMFORKS, vepNumForks);
+        pipelineOptions.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, allowStartIfComplete);
 
         logger.debug("Using as pipelineOptions: {}", pipelineOptions.entrySet().toString());
     }
@@ -253,14 +245,14 @@ public class JobOptions {
     }
 
     public String getDbCollectionsFeaturesName() {
-        return getPipelineOptions().getString(DB_COLLECTIONS_FEATURES_NAME);
+        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME);
     }
 
     public String getDbCollectionsVariantsName() {
-        return getPipelineOptions().getString(DB_COLLECTIONS_VARIANTS_NAME);
+        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
     }
     public String getDbCollectionsStatsName() {
-        return getPipelineOptions().getString(DB_COLLECTIONS_STATS_NAME);
+        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_STATS_NAME);
     }
 
     public String getVepInput() {
@@ -272,14 +264,14 @@ public class JobOptions {
     }
 
     public String getDbName() {
-        return getPipelineOptions().getString(DB_NAME);
+        return getPipelineOptions().getString(JobParametersNames.DB_NAME);
     }
 
     public void setDbName(String dbName) {
         this.dbName = dbName;
         getVariantOptions().put(VariantStorageManager.DB_NAME, dbName);
         getVariantOptions().put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME, dbName);
-        getPipelineOptions().put(DB_NAME, dbName);
+        getPipelineOptions().put(JobParametersNames.DB_NAME, dbName);
     }
 
     public String getVepOutput() {
@@ -291,7 +283,7 @@ public class JobOptions {
     }
 
     public void setAppVepPath(File appVepPath) {
-        getPipelineOptions().put(APP_VEP_PATH, appVepPath);
+        getPipelineOptions().put(JobParametersNames.APP_VEP_PATH, appVepPath);
     }
 
     public String getOutputDir() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -87,7 +87,7 @@ public class JobOptions {
     @Value("${" + JobParametersNames.DB_COLLECTIONS_FILES_NAME + ":#{null}}") private String dbCollectionFilesName;
     @Value("${" + JobParametersNames.DB_COLLECTIONS_FEATURES_NAME +"}") private String dbCollectionGenesName;
     @Value("${" + JobParametersNames.DB_COLLECTIONS_STATS_NAME + "}") private String dbCollectionStatsName;
-    @Value("${" + JobParametersNames.CONFIG_DB_READ_PREFERENCE + "}") private String readPreference;
+    @Value("${" + JobParametersNames.CONFIG_DB_READPREFERENCE + "}") private String readPreference;
 
     // Skip steps
     @Value("${" + JobParametersNames.ANNOTATION_SKIP + ":false}") private boolean skipAnnot;
@@ -203,7 +203,7 @@ public class JobOptions {
         pipelineOptions.put(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB, dbAuthenticationDb);
         pipelineOptions.put(JobParametersNames.CONFIG_DB_USER, dbUser);
         pipelineOptions.put(JobParametersNames.CONFIG_DB_PASSWORD, dbPassword);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_READ_PREFERENCE, readPreference);
+        pipelineOptions.put(JobParametersNames.CONFIG_DB_READPREFERENCE, readPreference);
         pipelineOptions.put(JobParametersNames.ANNOTATION_SKIP, skipAnnot);
         pipelineOptions.put(JobParametersNames.STATISTICS_SKIP, skipStats);
 
@@ -287,6 +287,6 @@ public class JobOptions {
     }
 
     public String getOutputDir() {
-        return getPipelineOptions().getString("output.dir");
+        return getPipelineOptions().getString(JobParametersNames.OUTPUT_DIR);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -126,25 +126,25 @@ public class JobOptions {
         properties.load(new InputStreamReader(new FileInputStream(configUri.getPath())));
 
         if (dbHosts == null) {
-            dbHosts = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.HOSTS");
+            dbHosts = properties.getProperty(JobParametersNames.OPENCGA_DB_HOSTS);
         }
         if (dbAuthenticationDb == null) {
-            dbAuthenticationDb = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.AUTHENTICATION.DB", "");
+            dbAuthenticationDb = properties.getProperty(JobParametersNames.OPENCGA_DB_AUTHENTICATIONDB, "");
         }
         if (dbUser == null) {
-            dbUser = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.USER", "");
+            dbUser = properties.getProperty(JobParametersNames.OPENCGA_DB_USER, "");
         }
         if (dbPassword == null) {
-            dbPassword = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.PASS", "");
+            dbPassword = properties.getProperty(JobParametersNames.OPENCGA_DB_PASSWORD, "");
         }
         if (dbName == null) {
-            dbName = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.NAME");
+            dbName = properties.getProperty(JobParametersNames.OPENCGA_DB_NAME);
         }
         if (dbCollectionVariantsName == null) {
-            dbCollectionVariantsName = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.COLLECTION.VARIANTS", "variants");
+            dbCollectionVariantsName = properties.getProperty(JobParametersNames.OPENCGA_DB_COLLECTIONS_VARIANTS_NAME, "variants");
         }
         if (dbCollectionFilesName == null) {
-            dbCollectionFilesName = properties.getProperty("OPENCGA.STORAGE.MONGODB.VARIANT.DB.COLLECTION.FILES", "files");
+            dbCollectionFilesName = properties.getProperty(JobParametersNames.OPENCGA_DB_COLLECTIONS_FILES_NAME, "files");
         }
 
         if (dbHosts == null || dbHosts.isEmpty()) {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -86,7 +86,7 @@ public class JobOptions {
     @Value("${" + JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME + ":#{null}}") private String dbCollectionVariantsName;
     @Value("${" + JobParametersNames.DB_COLLECTIONS_FILES_NAME + ":#{null}}") private String dbCollectionFilesName;
     @Value("${" + JobParametersNames.DB_COLLECTIONS_FEATURES_NAME +"}") private String dbCollectionGenesName;
-    @Value("${" + JobParametersNames.DB_COLLECTIONS_STATS_NAME + "}") private String dbCollectionStatsName;
+    @Value("${" + JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME + "}") private String dbCollectionStatsName;
     @Value("${" + JobParametersNames.CONFIG_DB_READPREFERENCE + "}") private String readPreference;
 
     // Skip steps
@@ -198,7 +198,7 @@ public class JobOptions {
         pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, dbCollectionVariantsName);
         pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FILES_NAME, dbCollectionFilesName);
         pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME, dbCollectionGenesName);
-        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_STATS_NAME, dbCollectionStatsName);
+        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME, dbCollectionStatsName);
         pipelineOptions.put(JobParametersNames.CONFIG_DB_HOSTS, dbHosts);
         pipelineOptions.put(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB, dbAuthenticationDb);
         pipelineOptions.put(JobParametersNames.CONFIG_DB_USER, dbUser);
@@ -252,7 +252,7 @@ public class JobOptions {
         return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
     }
     public String getDbCollectionsStatsName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_STATS_NAME);
+        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME);
     }
 
     public String getVepInput() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,7 +37,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Properties;
-import javax.annotation.PostConstruct;
 
 /**
  *

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.eva.pipeline.configuration;
 
+import org.opencb.opencga.storage.mongodb.variant.MongoDBVariantStorageManager;
+
 public class JobParametersNames {
 
     /*
@@ -82,6 +84,20 @@ public class JobParametersNames {
     
     public static final String APP_OPENCGA_PATH = "app.opencga.path";
 
+    public static final String OPENCGA_DB_NAME = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME;
+    
+    public static final String OPENCGA_DB_HOSTS = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_HOSTS;
+    
+    public static final String OPENCGA_DB_AUTHENTICATIONDB = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_AUTHENTICATION_DB;
+    
+    public static final String OPENCGA_DB_USER = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_USER;
+    
+    public static final String OPENCGA_DB_PASSWORD = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_PASS;
+
+    public static final String OPENCGA_DB_COLLECTIONS_VARIANTS_NAME = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_COLLECTION_VARIANTS;
+    
+    public static final String OPENCGA_DB_COLLECTIONS_FILES_NAME = MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_COLLECTION_FILES;
+    
     
     /*
      * Variant Effect Predictor (VEP)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
@@ -62,7 +62,7 @@ public class JobParametersNames {
     
     public static final String DB_COLLECTIONS_FEATURES_NAME = "db.collections.features.name";
     
-    public static final String DB_COLLECTIONS_STATS_NAME = "db.collections.stats.name";
+    public static final String DB_COLLECTIONS_STATISTICS_NAME = "db.collections.stats.name";
     
     
     /*

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
@@ -1,0 +1,106 @@
+package uk.ac.ebi.eva.pipeline.configuration;
+
+public class JobParametersNames {
+
+    /*
+     * Input
+     */
+    
+    public static final String INPUT_VCF = "input.vcf";
+    
+    public static final String INPUT_VCF_ID = "input.vcf.id";
+    
+    public static final String INPUT_VCF_AGGREGATION = "input.vcf.aggregation";
+    
+    public static final String INPUT_STUDY_NAME = "input.study.name";
+    
+    public static final String INPUT_STUDY_ID = "input.study.id";
+    
+    public static final String INPUT_STUDY_TYPE = "input.study.type";
+    
+    public static final String INPUT_PEDIGREE = "input.pedigree";
+    
+    public static final String INPUT_GTF = "input.gtf";
+
+    public static final String INPUT_FASTA = "input.fasta";
+
+    /*
+     * Output
+     */
+    
+    public static final String OUTPUT_DIR = "output.dir";
+    
+    public static final String OUTPUT_DIR_ANNOTATION = "output.dir.annotation";
+    
+    public static final String OUTPUT_DIR_STATISTICS = "output.dir.statistics";
+
+
+    /*
+     * Database infrastructure (most parameters read from OpenCGA "conf" folder)
+     */
+    
+    public static final String CONFIG_DB_HOSTS = "config.db.hosts";
+    
+    public static final String CONFIG_DB_AUTHENTICATIONDB = "config.db.authentication-db";
+    
+    public static final String CONFIG_DB_USER = "config.db.user";
+    
+    public static final String CONFIG_DB_PASSWORD = "config.db.password";
+    
+    public static final String CONFIG_DB_READ_PREFERENCE = "config.db.read-preference";
+    
+    
+    /*
+     * Database and collections
+     */
+    
+    public static final String DB_NAME = "db.name";
+    
+    public static final String DB_COLLECTIONS_VARIANTS_NAME = "db.collections.variants.name";
+    
+    public static final String DB_COLLECTIONS_FILES_NAME = "db.collections.files.name";
+    
+    public static final String DB_COLLECTIONS_FEATURES_NAME = "db.collections.features.name";
+    
+    public static final String DB_COLLECTIONS_STATS_NAME = "db.collections.stats.name";
+    
+    
+    /*
+     * Skip and overwrite steps
+     */
+    
+    public static final String ANNOTATION_SKIP = "annotation.skip";
+    
+    public static final String STATISTICS_SKIP = "statistics.skip";
+
+    public static final String STATISTICS_OVERWRITE = "statistics.overwrite";
+    
+    
+    /*
+     * OpenCGA
+     */
+    
+    public static final String APP_OPENCGA_PATH = "app.opencga.path";
+
+    
+    /*
+     * Variant Effect Predictor (VEP)
+     */
+    
+    public static final String APP_VEP_PATH = "app.vep.path";
+    
+    public static final String APP_VEP_CACHE_PATH = "app.vep.cache.path";
+    
+    public static final String APP_VEP_CACHE_VERSION = "app.vep.cache.version";
+    
+    public static final String APP_VEP_CACHE_SPECIES = "app.vep.cache.species";
+    
+    public static final String APP_VEP_NUMFORKS = "app.vep.num-forks";
+
+    
+    /*
+     * Other configuration
+     */
+    
+    public static final String CONFIG_RESTARTABILITY_ALLOW = "config.restartability.allow";
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
@@ -47,7 +47,7 @@ public class JobParametersNames {
     
     public static final String CONFIG_DB_PASSWORD = "config.db.password";
     
-    public static final String CONFIG_DB_READ_PREFERENCE = "config.db.read-preference";
+    public static final String CONFIG_DB_READPREFERENCE = "config.db.read-preference";
     
     
     /*

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -19,6 +19,8 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
 import org.opencb.datastore.core.ObjectMap;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import javax.annotation.PostConstruct;
@@ -35,8 +37,8 @@ public class NonAnnotatedVariantsMongoReader extends MongoDbCursorItemReader {
 
         setMongo(MongoDBHelper.getMongoClientFromPipelineOptions(pipelineOptions));
 
-        setDatabaseName(pipelineOptions.getString("db.name"));
-        setCollectionName(pipelineOptions.getString("db.collections.variants.name"));
+        setDatabaseName(pipelineOptions.getString(JobParametersNames.DB_NAME));
+        setCollectionName(pipelineOptions.getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME));
 
         DBObject refDbObject = BasicDBObjectBuilder.start().add("annot.ct.so", new BasicDBObject("$exists", false)).get();
         setRefDbObject(refDbObject);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/CommonJobStepInitialization.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/CommonJobStepInitialization.java
@@ -25,7 +25,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantNormalizerStep;
 
@@ -53,7 +55,7 @@ public abstract class CommonJobStepInitialization {
      */
     protected void initStep(final TaskletStepBuilder tasklet) {
 
-        boolean allowStartIfComplete = getPipelineOptions().getBoolean("config.restartability.allow");
+        boolean allowStartIfComplete = getPipelineOptions().getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
 
         // true: every job execution will do this step, even if this step is already COMPLETED
         // false(default): if the job was aborted and is relaunched, this step will NOT be done again

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
 import uk.ac.ebi.eva.pipeline.jobs.deciders.EmptyFileDecider;
 import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
@@ -22,7 +24,6 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep;
 @Import({VepAnnotationGeneratorStep.class, VepInputGeneratorStep.class, AnnotationLoaderStep.class})
 public class AnnotationFlow extends CommonJobStepInitialization {
 
-    public static final String SKIP_ANNOT = "annotation.skip";
     public static final String GENERATE_VEP_ANNOTATION = "Generate VEP annotation";
     private static final String OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW = "Optional variant VEP annotation flow";
     private static final String VARIANT_VEP_ANNOTATION_FLOW = "Variant VEP annotation flow";
@@ -40,7 +41,7 @@ public class AnnotationFlow extends CommonJobStepInitialization {
 
     @Bean
     Flow annotationFlowOptional() {
-        SkipStepDecider annotationSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_ANNOT);
+        SkipStepDecider annotationSkipStepDecider = new SkipStepDecider(getPipelineOptions(), JobParametersNames.ANNOTATION_SKIP);
 
         return new FlowBuilder<Flow>(OPTIONAL_VARIANT_VEP_ANNOTATION_FLOW)
                 .start(annotationSkipStepDecider).on(SkipStepDecider.DO_STEP)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlow.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
 import uk.ac.ebi.eva.pipeline.jobs.deciders.EmptyFileDecider;
@@ -53,7 +54,7 @@ public class AnnotationFlow extends CommonJobStepInitialization {
 
     @Bean
     Flow annotationFlowBasic() {
-        EmptyFileDecider emptyFileDecider = new EmptyFileDecider(getPipelineOptions().getString("vep.input"));
+        EmptyFileDecider emptyFileDecider = new EmptyFileDecider(getPipelineOptions().getString(JobOptions.VEP_INPUT));
 
         return new FlowBuilder<Flow>(VARIANT_VEP_ANNOTATION_FLOW)
                 .start(variantsAnnotGenerateInputBatchStep)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/PopulationStatisticsFlow.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/PopulationStatisticsFlow.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.CommonJobStepInitialization;
 import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
 import uk.ac.ebi.eva.pipeline.jobs.steps.PopulationStatisticsGeneratorStep;
@@ -19,7 +21,6 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.PopulationStatisticsLoaderStep;
 @Import({PopulationStatisticsGeneratorStep.class, PopulationStatisticsLoaderStep.class})
 public class PopulationStatisticsFlow extends CommonJobStepInitialization {
 
-    public static final String SKIP_STATS = "statistics.skip";
     public static final String CALCULATE_STATISTICS = "Calculate statistics";
     public static final String LOAD_STATISTICS = "Load statistics";
     private static final String STATS_FLOW = "statsFlow";
@@ -32,7 +33,7 @@ public class PopulationStatisticsFlow extends CommonJobStepInitialization {
 
     @Bean
     public Flow optionalStatisticsFlow() {
-        SkipStepDecider statisticsSkipStepDecider = new SkipStepDecider(getPipelineOptions(), SKIP_STATS);
+        SkipStepDecider statisticsSkipStepDecider = new SkipStepDecider(getPipelineOptions(), JobParametersNames.STATISTICS_SKIP);
 
         return new FlowBuilder<Flow>(STATS_FLOW)
                 .start(statisticsSkipStepDecider).on(SkipStepDecider.DO_STEP)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
@@ -73,7 +73,7 @@ public class AnnotationLoaderStep {
         VepAnnotationMongoWriter writer = new VepAnnotationMongoWriter(mongoOperations, collections);
 
         return stepBuilderFactory.get(LOAD_VEP_ANNOTATION).<VariantAnnotation, VariantAnnotation>chunk(10)
-                .reader(new AnnotationFlatFileReader(jobOptions.getPipelineOptions().getString("vep.output")))
+                .reader(new AnnotationFlatFileReader(jobOptions.getPipelineOptions().getString(JobOptions.VEP_OUTPUT)))
                 .writer(writer)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
                 .listener(new SkippedItemListener())

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.io.readers.AnnotationFlatFileReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VepAnnotationMongoWriter;
 import uk.ac.ebi.eva.pipeline.listeners.SkippedItemListener;
@@ -68,7 +69,7 @@ public class AnnotationLoaderStep {
     @Qualifier("annotationLoad")
     public Step annotationLoadBatchStep() throws IOException {
         MongoOperations mongoOperations = MongoDBHelper.getMongoOperationsFromPipelineOptions(jobOptions.getPipelineOptions());
-        String collections = jobOptions.getPipelineOptions().getString("db.collections.variants.name");
+        String collections = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         VepAnnotationMongoWriter writer = new VepAnnotationMongoWriter(mongoOperations, collections);
 
         return stepBuilderFactory.get(LOAD_VEP_ANNOTATION).<VariantAnnotation, VariantAnnotation>chunk(10)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
@@ -27,9 +27,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.io.readers.GeneReader;
 import uk.ac.ebi.eva.pipeline.io.writers.GeneWriter;
-import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.jobs.steps.processors.GeneFilterProcessor;
 import uk.ac.ebi.eva.pipeline.listeners.SkippedItemListener;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
@@ -66,7 +67,7 @@ public class GeneLoaderStep {
     @Qualifier("genesLoadStep")
     public Step genesLoadStep() throws IOException {
         return stepBuilderFactory.get(LOAD_FEATURES).<FeatureCoordinates, FeatureCoordinates>chunk(10)
-                .reader(new GeneReader(jobOptions.getPipelineOptions().getString("input.gtf")))
+                .reader(new GeneReader(jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_GTF)))
                 .processor(new GeneFilterProcessor())
                 .writer(new GeneWriter(jobOptions.getMongoOperations(), jobOptions.getDbCollectionsFeaturesName()))
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStep.java
@@ -16,10 +16,6 @@
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
 import com.mongodb.BasicDBObject;
-
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
-
 import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +28,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.stereotype.Component;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 /**
  * This step initializes the indexes in the databases.
@@ -51,7 +51,7 @@ public class IndexesGeneratorStep implements Tasklet {
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
         MongoOperations operations = MongoDBHelper.getMongoOperationsFromPipelineOptions(pipelineOptions);
-        operations.getCollection(pipelineOptions.getString("db.collections.features.name"))
+        operations.getCollection(pipelineOptions.getString(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME))
                 .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
 
         return RepeatStatus.FINISHED;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStep.java
@@ -28,7 +28,9 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 
 /**
  * Tasklet that parse and load a PED file into Mongo
@@ -51,7 +53,7 @@ public class PedLoaderStep implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        PedigreeReader pedigreeReader = new PedigreePedReader(jobOptions.getPipelineOptions().getString("input.pedigree"));
+        PedigreeReader pedigreeReader = new PedigreePedReader(jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_PEDIGREE));
         pedigreeReader.open();
         pedigree = pedigreeReader.read().get(0);
         pedigreeReader.close();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2016 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.net.URI;
@@ -65,7 +67,7 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
         VariantSource variantSource = variantOptions.get(VariantStorageManager.VARIANT_SOURCE, VariantSource.class);
         VariantDBAdaptor dbAdaptor = variantStorageManager.getDBAdaptor(
                 variantOptions.getString(VariantStorageManager.DB_NAME), variantOptions);
-        URI outdirUri = URLHelper.createUri(pipelineOptions.getString("output.dir.statistics"));
+        URI outdirUri = URLHelper.createUri(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS));
         URI statsOutputUri = outdirUri.resolve(VariantStorageManager.buildFilename(variantSource));
 
         VariantStatisticsManager variantStatisticsManager = new VariantStatisticsManager();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2016 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.net.URI;
@@ -93,7 +95,7 @@ public class PopulationStatisticsLoaderStep implements Tasklet {
         VariantSource variantSource = variantOptions.get(VariantStorageManager.VARIANT_SOURCE, VariantSource.class);
         VariantDBAdaptor dbAdaptor = variantStorageManager.getDBAdaptor(
                 variantOptions.getString(VariantStorageManager.DB_NAME), variantOptions);
-        URI outdirUri = URLHelper.createUri(pipelineOptions.getString("output.dir.statistics"));
+        URI outdirUri = URLHelper.createUri(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS));
         URI statsOutputUri = outdirUri.resolve(VariantStorageManager.buildFilename(variantSource));
 
         VariantStatisticsManager variantStatisticsManager = new VariantStatisticsManager();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
@@ -60,9 +60,9 @@ public class VariantLoaderStep implements Tasklet {
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();// TODO add mongo
 
         URI outdirUri = FileUtils.getPathUri(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR),true);
-        URI nextFileUri = URLHelper.createUri(pipelineOptions.getString("input.vcf"));
+        URI nextFileUri = URLHelper.createUri(pipelineOptions.getString(JobParametersNames.INPUT_VCF));
 
-//          URI pedigreeUri = pipelineOptions.getString("input.pedigree") != null ? createUri(pipelineOptions.getString("input.pedigree")) : null;
+//          URI pedigreeUri = pipelineOptions.getString(JobParametersNames.INPUT_PEDIGREE) != null ? createUri(pipelineOptions.getString(JobParametersNames.INPUT_PEDIGREE)) : null;
         Path output = Paths.get(outdirUri.getPath());
         Path input = Paths.get(nextFileUri.getPath());
         Path outputVariantJsonFile = output.resolve(input.getFileName().toString() + ".variants.json" + pipelineOptions.getString("compressExtension"));

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2016 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.utils.FileUtils;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -58,7 +59,7 @@ public class VariantLoaderStep implements Tasklet {
 
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();// TODO add mongo
 
-        URI outdirUri = FileUtils.getPathUri(pipelineOptions.getString(JobOptions.OUTPUT_DIR),true);
+        URI outdirUri = FileUtils.getPathUri(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR),true);
         URI nextFileUri = URLHelper.createUri(pipelineOptions.getString("input.vcf"));
 
 //          URI pedigreeUri = pipelineOptions.getString("input.pedigree") != null ? createUri(pipelineOptions.getString("input.pedigree")) : null;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
@@ -59,7 +59,7 @@ public class VariantNormalizerStep implements Tasklet {
 
         URI outdirUri = FileUtils.getPathUri(outputDirPath,true);
         URI nextFileUri = URLHelper.createUri(inputVcf);
-        URI pedigreeUri =  inputPedigree!= null ? URLHelper.createUri(inputPedigree) : null;
+        URI pedigreeUri =  inputPedigree != null ? URLHelper.createUri(inputPedigree) : null;
 
         logger.info("Transform file {} to {}", inputVcf, outputDirPath);
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
@@ -54,8 +54,8 @@ public class VariantNormalizerStep implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         String outputDirPath = pipelineOptions.getString(JobParametersNames.OUTPUT_DIR);
-        String inputVcf = pipelineOptions.getString("input.vcf");
-        String inputPedigree = pipelineOptions.getString("input.pedigree");
+        String inputVcf = pipelineOptions.getString(JobParametersNames.INPUT_VCF);
+        String inputPedigree = pipelineOptions.getString(JobParametersNames.INPUT_PEDIGREE);
 
         URI outdirUri = FileUtils.getPathUri(outputDirPath,true);
         URI nextFileUri = URLHelper.createUri(inputVcf);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2016 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.utils.FileUtils;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -52,7 +53,7 @@ public class VariantNormalizerStep implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        String outputDirPath = pipelineOptions.getString(JobOptions.OUTPUT_DIR);
+        String outputDirPath = pipelineOptions.getString(JobParametersNames.OUTPUT_DIR);
         String inputVcf = pipelineOptions.getString("input.vcf");
         String inputPedigree = pipelineOptions.getString("input.pedigree");
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
@@ -26,9 +26,15 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
 
-import java.io.*;
+import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
+
+import java.io.BufferedInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.zip.GZIPOutputStream;
 
@@ -68,7 +74,7 @@ public class VepAnnotationGeneratorStep implements Tasklet {
                 "--cache_version", pipelineOptions.getString("app.vep.cache.version"),
                 "-dir", pipelineOptions.getString("app.vep.cache.path"),
                 "--species", pipelineOptions.getString("app.vep.cache.species"),
-                "--fasta", pipelineOptions.getString("input.fasta"),
+                "--fasta", pipelineOptions.getString(JobParametersNames.INPUT_FASTA),
                 "--fork", pipelineOptions.getString("app.vep.num-forks"),
                 "-i", pipelineOptions.getString("vep.input"),
                 "-o", "STDOUT",

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
@@ -76,7 +76,7 @@ public class VepAnnotationGeneratorStep implements Tasklet {
                 "--species", pipelineOptions.getString(JobParametersNames.APP_VEP_CACHE_SPECIES),
                 "--fasta", pipelineOptions.getString(JobParametersNames.INPUT_FASTA),
                 "--fork", pipelineOptions.getString(JobParametersNames.APP_VEP_NUMFORKS),
-                "-i", pipelineOptions.getString("vep.input"),
+                "-i", pipelineOptions.getString(JobOptions.VEP_INPUT),
                 "-o", "STDOUT",
                 "--force_overwrite",
                 "--offline",
@@ -90,13 +90,13 @@ public class VepAnnotationGeneratorStep implements Tasklet {
 
         long written = connectStreams(
                 new BufferedInputStream(process.getInputStream()),
-                new GZIPOutputStream(new FileOutputStream(pipelineOptions.getString("vep.output"))));
+                new GZIPOutputStream(new FileOutputStream(pipelineOptions.getString(JobOptions.VEP_OUTPUT))));
 
         int exitValue = process.waitFor();
         logger.info("Finishing read from VEP output, bytes written: " + written);
 
         if (exitValue > 0) {
-            String errorLog = pipelineOptions.getString("vep.output") + ".errors.txt";
+            String errorLog = pipelineOptions.getString(JobOptions.VEP_OUTPUT) + ".errors.txt";
             connectStreams(new BufferedInputStream(process.getErrorStream()), new FileOutputStream(errorLog));
             throw new Exception("Error while running VEP (exit status " + exitValue + "). See "
                     + errorLog + " for the errors description from VEP.");

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepAnnotationGeneratorStep.java
@@ -69,13 +69,13 @@ public class VepAnnotationGeneratorStep implements Tasklet {
         ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
 
         ProcessBuilder processBuilder = new ProcessBuilder("perl",
-                pipelineOptions.getString("app.vep.path"),
+                pipelineOptions.getString(JobParametersNames.APP_VEP_PATH),
                 "--cache",
-                "--cache_version", pipelineOptions.getString("app.vep.cache.version"),
-                "-dir", pipelineOptions.getString("app.vep.cache.path"),
-                "--species", pipelineOptions.getString("app.vep.cache.species"),
+                "--cache_version", pipelineOptions.getString(JobParametersNames.APP_VEP_CACHE_VERSION),
+                "-dir", pipelineOptions.getString(JobParametersNames.APP_VEP_CACHE_PATH),
+                "--species", pipelineOptions.getString(JobParametersNames.APP_VEP_CACHE_SPECIES),
                 "--fasta", pipelineOptions.getString(JobParametersNames.INPUT_FASTA),
-                "--fork", pipelineOptions.getString("app.vep.num-forks"),
+                "--fork", pipelineOptions.getString(JobParametersNames.APP_VEP_NUMFORKS),
                 "-i", pipelineOptions.getString("vep.input"),
                 "-o", "STDOUT",
                 "--force_overwrite",

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
@@ -26,7 +26,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VepInputFlatFileWriter;
 import uk.ac.ebi.eva.pipeline.jobs.steps.processors.AnnotationProcessor;
@@ -70,7 +72,7 @@ public class VepInputGeneratorStep {
                 .reader(new NonAnnotatedVariantsMongoReader(jobOptions.getPipelineOptions()))
                 .processor(new AnnotationProcessor())
                 .writer(new VepInputFlatFileWriter(jobOptions.getVepInput()))
-                .allowStartIfComplete(jobOptions.getPipelineOptions().getBoolean("config.restartability.allow"))
+                .allowStartIfComplete(jobOptions.getPipelineOptions().getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW))
                 .build();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -47,11 +47,11 @@ public class MongoDBHelper {
         MongoTemplate mongoTemplate;
         if (pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB).isEmpty()) {
             mongoTemplate = ConnectionHelper.getMongoTemplate(
-                    pipelineOptions.getString("db.name")
+                    pipelineOptions.getString(JobParametersNames.DB_NAME)
             );
         } else {
             mongoTemplate = ConnectionHelper.getMongoTemplate(
-                    pipelineOptions.getString("db.name"),
+                    pipelineOptions.getString(JobParametersNames.DB_NAME),
                     pipelineOptions.getString(JobParametersNames.CONFIG_DB_HOSTS),
                     pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB),
                     pipelineOptions.getString(JobParametersNames.CONFIG_DB_USER),

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -24,6 +24,8 @@ import org.opencb.datastore.core.ObjectMap;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
+
 import java.net.UnknownHostException;
 
 /**
@@ -43,21 +45,21 @@ public class MongoDBHelper {
 
     private static MongoTemplate getMongoTemplate(ObjectMap pipelineOptions) throws UnknownHostException {
         MongoTemplate mongoTemplate;
-        if (pipelineOptions.getString("config.db.authentication-db").isEmpty()) {
+        if (pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB).isEmpty()) {
             mongoTemplate = ConnectionHelper.getMongoTemplate(
                     pipelineOptions.getString("db.name")
             );
         } else {
             mongoTemplate = ConnectionHelper.getMongoTemplate(
                     pipelineOptions.getString("db.name"),
-                    pipelineOptions.getString("config.db.hosts"),
-                    pipelineOptions.getString("config.db.authentication-db"),
-                    pipelineOptions.getString("config.db.user"),
-                    pipelineOptions.getString("config.db.password").toCharArray()
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_HOSTS),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_USER),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_PASSWORD).toCharArray()
             );
         }
 
-        mongoTemplate.setReadPreference(getMongoTemplateReadPreferences(pipelineOptions.getString("config.db.read-preference")));
+        mongoTemplate.setReadPreference(getMongoTemplateReadPreferences(pipelineOptions.getString(JobParametersNames.CONFIG_DB_READPREFERENCE)));
 
         return mongoTemplate;
     }
@@ -76,18 +78,18 @@ public class MongoDBHelper {
     private static Mongo getMongoClient(ObjectMap pipelineOptions) throws UnknownHostException {
         MongoClient mongoClient;
 
-        if (pipelineOptions.getString("config.db.authentication-db").isEmpty()) {
+        if (pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB).isEmpty()) {
             mongoClient = ConnectionHelper.getMongoClient();
         } else {
             mongoClient = ConnectionHelper.getMongoClient(
-                    pipelineOptions.getString("config.db.hosts"),
-                    pipelineOptions.getString("config.db.authentication-db"),
-                    pipelineOptions.getString("config.db.user"),
-                    pipelineOptions.getString("config.db.password").toCharArray()
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_HOSTS),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_USER),
+                    pipelineOptions.getString(JobParametersNames.CONFIG_DB_PASSWORD).toCharArray()
             );
         }
 
-        mongoClient.setReadPreference(getMongoTemplateReadPreferences(pipelineOptions.getString("config.db.read-preference")));
+        mongoClient.setReadPreference(getMongoTemplateReadPreferences(pipelineOptions.getString(JobParametersNames.CONFIG_DB_READPREFERENCE)));
 
         return mongoClient;
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -34,14 +34,14 @@ public class CommonConfiguration {
         PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
 
         Properties properties = new Properties();
-        properties.put("input.vcf", "");
-        properties.put("input.vcf.id", "1");
-        properties.put("input.vcf.aggregation", "NONE");
-        properties.put("input.study.type", "COLLECTION");
-        properties.put("input.study.name", "input.study.name");
-        properties.put("input.study.id", "1");
-        properties.put("input.pedigree", "");
-        properties.put("input.gtf", "");
+        properties.put(JobParametersNames.INPUT_VCF, "");
+        properties.put(JobParametersNames.INPUT_VCF_ID, "1");
+        properties.put(JobParametersNames.INPUT_VCF_AGGREGATION, "NONE");
+        properties.put(JobParametersNames.INPUT_STUDY_TYPE, "COLLECTION");
+        properties.put(JobParametersNames.INPUT_STUDY_NAME, JobParametersNames.INPUT_STUDY_NAME);
+        properties.put(JobParametersNames.INPUT_STUDY_ID, "1");
+        properties.put(JobParametersNames.INPUT_PEDIGREE, "");
+        properties.put(JobParametersNames.INPUT_GTF, "");
         properties.put("input.fasta", "");
 
         properties.put(JobParametersNames.OUTPUT_DIR, "/tmp");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -42,11 +42,11 @@ public class CommonConfiguration {
         properties.put(JobParametersNames.INPUT_STUDY_ID, "1");
         properties.put(JobParametersNames.INPUT_PEDIGREE, "");
         properties.put(JobParametersNames.INPUT_GTF, "");
-        properties.put("input.fasta", "");
+        properties.put(JobParametersNames.INPUT_FASTA, "");
 
         properties.put(JobParametersNames.OUTPUT_DIR, "/tmp");
-        properties.put("output.dir.annotation", "");
-        properties.put("output.dir.statistics", "/tmp");
+        properties.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, "");
+        properties.put(JobParametersNames.OUTPUT_DIR_STATISTICS, "/tmp");
 
         properties.put("statistics.overwrite", "false");
 
@@ -56,7 +56,7 @@ public class CommonConfiguration {
         properties.put("db.collection.files.name", "files");
         properties.put("db.collections.features.name", "features");
         properties.put("db.collections.stats.name", "populationStatistics");
-        properties.put("config.db.read-preference", "primary");
+        properties.put(JobParametersNames.CONFIG_DB_READPREFERENCE, "primary");
 
         properties.put("app.opencga.path", opencgaHome);
         properties.put("app.vep.path", "");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -44,7 +44,7 @@ public class CommonConfiguration {
         properties.put("input.gtf", "");
         properties.put("input.fasta", "");
 
-        properties.put(JobOptions.OUTPUT_DIR, "/tmp");
+        properties.put(JobParametersNames.OUTPUT_DIR, "/tmp");
         properties.put("output.dir.annotation", "");
         properties.put("output.dir.statistics", "/tmp");
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -48,14 +48,14 @@ public class CommonConfiguration {
         properties.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, "");
         properties.put(JobParametersNames.OUTPUT_DIR_STATISTICS, "/tmp");
 
-        properties.put("statistics.overwrite", "false");
+        properties.put(JobParametersNames.STATISTICS_OVERWRITE, "false");
 
         properties.put("db.hosts", "localhost:27017");
 //        properties.put("dbName", null);
         properties.put("db.collection.variants.name", "variants");
         properties.put("db.collection.files.name", "files");
-        properties.put("db.collections.features.name", "features");
-        properties.put("db.collections.stats.name", "populationStatistics");
+        properties.put(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME, "features");
+        properties.put(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME, "populationStatistics");
         properties.put(JobParametersNames.CONFIG_DB_READPREFERENCE, "primary");
 
         properties.put("app.opencga.path", opencgaHome);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -58,14 +58,14 @@ public class CommonConfiguration {
         properties.put(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME, "populationStatistics");
         properties.put(JobParametersNames.CONFIG_DB_READPREFERENCE, "primary");
 
-        properties.put("app.opencga.path", opencgaHome);
-        properties.put("app.vep.path", "");
-        properties.put("app.vep.cache.path", "");
-        properties.put("app.vep.cache.version", "");
-        properties.put("app.vep.cache.species", "");
-        properties.put("app.vep.num-forks", "3");
+        properties.put(JobParametersNames.APP_OPENCGA_PATH, opencgaHome);
+        properties.put(JobParametersNames.APP_VEP_PATH, "");
+        properties.put(JobParametersNames.APP_VEP_CACHE_PATH, "");
+        properties.put(JobParametersNames.APP_VEP_CACHE_VERSION, "");
+        properties.put(JobParametersNames.APP_VEP_CACHE_SPECIES, "");
+        properties.put(JobParametersNames.APP_VEP_NUMFORKS, "3");
 
-        properties.put("config.restartability.allow", false);
+        properties.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, false);
 
         configurer.setProperties(properties);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -15,7 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.io.writers;
 
-import com.mongodb.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,16 +30,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.AnnotationConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 
 /**
@@ -100,7 +112,7 @@ public class VepAnnotationMongoWriterTest {
     @Test
     public void shouldWriteAllFieldsIntoMongoDbMultipleSetsAnnotations() throws Exception {
         String dbName = jobOptions.getDbName();
-        String dbCollectionVariantsName = jobOptions.getPipelineOptions().getString("db.collections.variants.name");
+        String dbCollectionVariantsName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
 
         List<VariantAnnotation> annotations = new ArrayList<>();
         for (String annotLine : vepOutputContent.split("\n")) {
@@ -131,7 +143,7 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        String collections = jobOptions.getPipelineOptions().getString("db.collections.variants.name");
+        String collections = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         annotationWriter = new VepAnnotationMongoWriter(mongoOperations, collections);
 
         annotationWriter.write(annotationSet1);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -15,7 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.datastore.core.QueryOptions;
@@ -33,7 +37,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.configuration.VariantAggregatedConfiguration;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -44,7 +50,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.cleanDBs;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.getTransformedOutputPath;
 
@@ -155,13 +163,13 @@ public class AggregatedVcfJobTest {
     public void setUp() throws Exception {
         jobOptions.loadArgs();
 
-        input = jobOptions.getPipelineOptions().getString("input.vcf");
+        input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
         dbName = jobOptions.getPipelineOptions().getString("db.name");
 
         String inputFile = AggregatedVcfJobTest.class.getResource(input).getFile();
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
     }
 
     @After

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -166,7 +166,7 @@ public class AggregatedVcfJobTest {
         input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
-        dbName = jobOptions.getPipelineOptions().getString("db.name");
+        dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
 
         String inputFile = AggregatedVcfJobTest.class.getResource(input).getFile();
         jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -219,7 +219,7 @@ public class GenotypedVcfJobTest {
         input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
-        dbName = jobOptions.getPipelineOptions().getString("db.name");
+        dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
         vepInput = jobOptions.getPipelineOptions().getString("vep.input");
         vepOutput = jobOptions.getPipelineOptions().getString("vep.output");
         JobTestUtils.cleanDBs(dbName);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -101,7 +101,7 @@ public class GenotypedVcfJobTest {
         String mockVep = GenotypedVcfJobTest.class.getResource("/mockvep.pl").getFile();
 
         jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
-        jobOptions.getPipelineOptions().put("app.vep.path", mockVep);
+        jobOptions.getPipelineOptions().put(JobParametersNames.APP_VEP_PATH, mockVep);
 
         Config.setOpenCGAHome(opencgaHome);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -38,8 +38,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -54,7 +56,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.getLines;
 
@@ -95,7 +100,7 @@ public class GenotypedVcfJobTest {
         String inputFile = GenotypedVcfJobTest.class.getResource(input).getFile();
         String mockVep = GenotypedVcfJobTest.class.getResource("/mockvep.pl").getFile();
 
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
         jobOptions.getPipelineOptions().put("app.vep.path", mockVep);
 
         Config.setOpenCGAHome(opencgaHome);
@@ -211,7 +216,7 @@ public class GenotypedVcfJobTest {
     public void setUp() throws Exception {
         jobOptions.loadArgs();
 
-        input = jobOptions.getPipelineOptions().getString("input.vcf");
+        input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
         dbName = jobOptions.getPipelineOptions().getString("db.name");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -220,8 +220,8 @@ public class GenotypedVcfJobTest {
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
         dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
-        vepInput = jobOptions.getPipelineOptions().getString("vep.input");
-        vepOutput = jobOptions.getPipelineOptions().getString("vep.output");
+        vepInput = jobOptions.getPipelineOptions().getString(JobOptions.VEP_INPUT);
+        vepOutput = jobOptions.getPipelineOptions().getString(JobOptions.VEP_OUTPUT);
         JobTestUtils.cleanDBs(dbName);
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -239,7 +239,7 @@ public class GenotypedVcfJobWorkflowTest {
     public void setUp() throws Exception {
         jobOptions.loadArgs();
 
-        inputFileResouce = jobOptions.getPipelineOptions().getString("input.vcf");
+        inputFileResouce = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
         dbName = jobOptions.getPipelineOptions().getString("db.name");
@@ -257,7 +257,7 @@ public class GenotypedVcfJobWorkflowTest {
         String inputFile = GenotypedVcfJobTest.class.getResource(inputFileResouce).getFile();
         String mockVep = GenotypedVcfJobTest.class.getResource("/mockvep.pl").getFile();
 
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
         jobOptions.getPipelineOptions().put("app.vep.path", mockVep);
 
         Config.setOpenCGAHome(opencgaHome);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -243,8 +243,8 @@ public class GenotypedVcfJobWorkflowTest {
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
         dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
-        vepInput = jobOptions.getPipelineOptions().getString("vep.input");
-        vepOutput = jobOptions.getPipelineOptions().getString("vep.output");
+        vepInput = jobOptions.getPipelineOptions().getString(JobOptions.VEP_INPUT);
+        vepOutput = jobOptions.getPipelineOptions().getString(JobOptions.VEP_OUTPUT);
         JobTestUtils.cleanDBs(dbName);
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -258,7 +258,7 @@ public class GenotypedVcfJobWorkflowTest {
         String mockVep = GenotypedVcfJobTest.class.getResource("/mockvep.pl").getFile();
 
         jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
-        jobOptions.getPipelineOptions().put("app.vep.path", mockVep);
+        jobOptions.getPipelineOptions().put(JobParametersNames.APP_VEP_PATH, mockVep);
 
         Config.setOpenCGAHome(opencgaHome);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -31,9 +31,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfWorkflowConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
-import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VepAnnotationGeneratorStep;
@@ -42,9 +43,17 @@ import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Workflow test for {@link GenotypedVcfJob}
@@ -121,8 +130,8 @@ public class GenotypedVcfJobWorkflowTest {
     public void optionalStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
 
-        jobOptions.getPipelineOptions().put(AnnotationFlow.SKIP_ANNOT, true);
-        jobOptions.getPipelineOptions().put(PopulationStatisticsFlow.SKIP_STATS, true);
+        jobOptions.getPipelineOptions().put(JobParametersNames.ANNOTATION_SKIP, true);
+        jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, true);
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
 
@@ -142,7 +151,7 @@ public class GenotypedVcfJobWorkflowTest {
     @Test
     public void statsStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(PopulationStatisticsFlow.SKIP_STATS, true);
+        jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, true);
 
         jobOptions.getPipelineOptions().put("db.name", "diegoTest");
 
@@ -186,7 +195,7 @@ public class GenotypedVcfJobWorkflowTest {
     @Test
     public void annotationStepsShouldBeSkipped() throws Exception {
         initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(AnnotationFlow.SKIP_ANNOT, true);
+        jobOptions.getPipelineOptions().put(JobParametersNames.ANNOTATION_SKIP, true);
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -153,7 +153,7 @@ public class GenotypedVcfJobWorkflowTest {
         initVariantConfigurationJob();
         jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, true);
 
-        jobOptions.getPipelineOptions().put("db.name", "diegoTest");
+        jobOptions.getPipelineOptions().put(JobParametersNames.DB_NAME, "diegoTest");
 
 
         JobExecution execution = jobLauncherTestUtils.launchJob();
@@ -242,7 +242,7 @@ public class GenotypedVcfJobWorkflowTest {
         inputFileResouce = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         compressExtension = jobOptions.getPipelineOptions().getString("compressExtension");
-        dbName = jobOptions.getPipelineOptions().getString("db.name");
+        dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
         vepInput = jobOptions.getPipelineOptions().getString("vep.input");
         vepOutput = jobOptions.getPipelineOptions().getString("vep.output");
         JobTestUtils.cleanDBs(dbName);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -35,15 +35,19 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 
@@ -77,7 +81,7 @@ public class PopulationStatisticsJobTest {
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
 
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
 
         VariantSource source = new VariantSource(
                 input,

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -93,7 +93,7 @@ public class PopulationStatisticsJobTest {
 
         variantOptions.put(VARIANT_SOURCE, source);
 
-        statsFile = new File(Paths.get(pipelineOptions.getString("output.dir.statistics"))
+        statsFile = new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS))
                 .resolve(VariantStorageManager.buildFilename(source)) + ".variants.stats.json.gz");
         statsFile.delete();
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
@@ -109,7 +109,7 @@ public class PopulationStatisticsJobTest {
 
         //delete created files
         statsFile.delete();
-        new File(Paths.get(pipelineOptions.getString("output.dir.statistics")).resolve(VariantStorageManager.buildFilename(source))
+        new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS)).resolve(VariantStorageManager.buildFilename(source))
                 + ".source.stats.json.gz").delete();
 
         // The DB docs should have the field "st"
@@ -128,7 +128,7 @@ public class PopulationStatisticsJobTest {
         String dump = PopulationStatisticsJobTest.class.getResource("/dump/").getFile();
         restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
-        String outputDir = pipelineOptions.getString("output.dir.statistics");
+        String outputDir = pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS);
 
         // copy stat file to load
         String variantsFileName = "/1_1.variants.stats.json.gz";

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PedLoaderStepTest.java
@@ -31,8 +31,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 
 import java.util.stream.Collectors;
 
@@ -61,7 +63,7 @@ public class PedLoaderStepTest {
     @Test
     public void allPedFileShouldBeParsedIntoPedigree() throws Exception {
         String pedigreeFile = PedLoaderStepTest.class.getResource("/ped/pedigree-test-file.ped").getFile();
-        jobOptions.getPipelineOptions().put("input.pedigree", pedigreeFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_PEDIGREE, pedigreeFile);
 
         ReflectionTestUtils.setField(pedLoaderStep, "jobOptions", jobOptions);
         RepeatStatus status = pedLoaderStep.execute(stepContribution, chunkContext);
@@ -91,7 +93,7 @@ public class PedLoaderStepTest {
     @Test(expected = IllegalArgumentException.class)
     public void missingLastColumnInPedFileShouldThrowsException() throws Exception {
         String pedigreeFile = PedLoaderStepTest.class.getResource("/ped/malformed-pedigree-test-file.ped").getFile();
-        jobOptions.getPipelineOptions().put("input.pedigree", pedigreeFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_PEDIGREE, pedigreeFile);
 
         ReflectionTestUtils.setField(pedLoaderStep, "jobOptions", jobOptions);
         pedLoaderStep.execute(stepContribution, chunkContext);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -30,8 +30,10 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
 import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
@@ -40,7 +42,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.restoreMongoDbFromDump;
 
@@ -71,7 +75,7 @@ public class PopulationStatisticsGeneratorStepTest {
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
 
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
 
         VariantSource source = new VariantSource(
                 input,
@@ -114,7 +118,7 @@ public class PopulationStatisticsGeneratorStepTest {
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
 
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
 
         VariantSource source = new VariantSource(
                 input,

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -87,7 +87,7 @@ public class PopulationStatisticsGeneratorStepTest {
 
         variantOptions.put(VARIANT_SOURCE, source);
 
-        statsFile = new File(Paths.get(pipelineOptions.getString("output.dir.statistics")).resolve(VariantStorageManager.buildFilename(source))
+        statsFile = new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS)).resolve(VariantStorageManager.buildFilename(source))
                 + ".variants.stats.json.gz");
         statsFile.delete();
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
@@ -104,7 +104,7 @@ public class PopulationStatisticsGeneratorStepTest {
 
         //delete created files
         statsFile.delete();
-        new File(Paths.get(pipelineOptions.getString("output.dir.statistics")).resolve(VariantStorageManager.buildFilename(source))
+        new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS)).resolve(VariantStorageManager.buildFilename(source))
                 + ".source.stats.json.gz").delete();
 
     }
@@ -130,7 +130,7 @@ public class PopulationStatisticsGeneratorStepTest {
 
         variantOptions.put(VARIANT_SOURCE, source);
 
-        statsFile = new File(Paths.get(pipelineOptions.getString("output.dir.statistics")).resolve(VariantStorageManager.buildFilename(source))
+        statsFile = new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS)).resolve(VariantStorageManager.buildFilename(source))
                 + ".variants.stats.json.gz");
         statsFile.delete();
         assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -78,7 +78,7 @@ public class PopulationStatisticsLoaderStepTest {
         String dump = PopulationStatisticsLoaderStepTest.class.getResource("/dump/VariantStatsConfigurationTest_vl").getFile();
         restoreMongoDbFromDump(dump, jobOptions.getDbName());
 
-        String outputDir = pipelineOptions.getString("output.dir.statistics");
+        String outputDir = pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS);
 
         // copy stat file to load
         String variantsFileName = "/1_1.variants.stats.json.gz";

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -23,8 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.CommonConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
 import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
@@ -69,7 +71,7 @@ public class PopulationStatisticsLoaderStepTest {
         String input = PopulationStatisticsLoaderStepTest.class.getResource(SMALL_VCF_FILE).getFile();
         VariantSource source = new VariantSource(input, "1", "1", "studyName");
 
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
 
         //and a valid variants load and stats create steps already completed
@@ -119,14 +121,14 @@ public class PopulationStatisticsLoaderStepTest {
         String input = PopulationStatisticsLoaderStepTest.class.getResource(SMALL_VCF_FILE).getFile();
         VariantSource source = new VariantSource(input, "4", "1", "studyName");
 
-        pipelineOptions.put("input.vcf", input);
+        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
         variantOptions.put(VariantStorageManager.DB_NAME, jobOptions.getDbName());
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.LOAD_STATISTICS);
         assertThat(capture.toString(), containsString("java.io.FileNotFoundException:"));
 
-        assertEquals(input, pipelineOptions.getString("input.vcf"));
+        assertEquals(input, pipelineOptions.getString(JobParametersNames.INPUT_VCF));
         assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -145,7 +145,7 @@ public class VariantLoaderStepTest {
 
         input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
-        dbName = jobOptions.getPipelineOptions().getString("db.name");
+        dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
     }
 
     @After

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -36,8 +36,10 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -118,7 +120,7 @@ public class VariantLoaderStepTest {
 
         Config.setOpenCGAHome("");
 
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
         jobOptions.getVariantOptions().put(VariantStorageManager.DB_NAME, dbName);
 
         VariantSource source = (VariantSource) jobOptions.getVariantOptions().get(VariantStorageManager.VARIANT_SOURCE);
@@ -133,7 +135,7 @@ public class VariantLoaderStepTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(GenotypedVcfJob.LOAD_VARIANTS);
 
-        assertEquals(inputFile, jobOptions.getPipelineOptions().getString("input.vcf"));
+        assertEquals(inputFile, jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF));
         assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
     }
 
@@ -141,7 +143,7 @@ public class VariantLoaderStepTest {
     public void setUp() throws Exception {
         jobOptions.loadArgs();
 
-        input = jobOptions.getPipelineOptions().getString("input.vcf");
+        input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         dbName = jobOptions.getPipelineOptions().getString("db.name");
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
@@ -28,8 +28,10 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.GenotypedVcfConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.JobOptions;
+import uk.ac.ebi.eva.pipeline.configuration.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;
 
@@ -70,7 +72,7 @@ public class VariantNormalizerStepTest {
         Config.setOpenCGAHome(opencgaHome);
 
         String inputFile = VariantNormalizerStepTest.class.getResource(input).getFile();
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
 
         String outputFilename = getTransformedOutputPath(Paths.get(input).getFileName(), ".gz", "/tmp");
 
@@ -104,7 +106,7 @@ public class VariantNormalizerStepTest {
 
         //Given a malformed VCF input file
         String inputFile = VariantNormalizerStepTest.class.getResource(FILE_WRONG_NO_ALT).getFile();
-        jobOptions.getPipelineOptions().put("input.vcf", inputFile);
+        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, inputFile);
 
         String outputFilename = getTransformedOutputPath(Paths.get(FILE_WRONG_NO_ALT).getFileName(), ".gz", "/tmp");
 
@@ -121,7 +123,7 @@ public class VariantNormalizerStepTest {
     public void setUp() throws Exception {
         jobOptions.loadArgs();
 
-        input = jobOptions.getPipelineOptions().getString("input.vcf");
+        input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
         dbName = jobOptions.getPipelineOptions().getString("db.name");
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantNormalizerStepTest.java
@@ -125,7 +125,7 @@ public class VariantNormalizerStepTest {
 
         input = jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF);
         outputDir = jobOptions.getOutputDir();
-        dbName = jobOptions.getPipelineOptions().getString("db.name");
+        dbName = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_NAME);
     }
 
     @After


### PR DESCRIPTION
Currently job parameters names are spread across the whole code using plain text strings. They have been moved into a new `JobParametersNames` class, listed as constants and used as such everywhere (automated replacement via `sed`).

It will also make easier to refer to them when validations are spread across multiple classes.