### PR TITLE
EVA-572 Spring Data MongoDB jobparameters

### DIFF
--- a/examples/application.properties
+++ b/examples/application.properties
@@ -24,9 +24,16 @@ config.restartability.allow=false
 
 
 # MONGO DATABASE
+spring.data.mongodb.host=
+spring.data.mongodb.authentication-database=
+spring.data.mongodb.username=
+spring.data.mongodb.password=
+spring.data.mongodb.database=
 config.db.read-preference=primary
 db.collections.features.name=features
+db.collections.files.name=files
 db.collections.stats.name=populationStatistics
+db.collections.variants.name=variants
 
 
 # LOGGING

--- a/examples/application.properties
+++ b/examples/application.properties
@@ -25,14 +25,17 @@ config.restartability.allow=false
 
 # MONGO DATABASE
 spring.data.mongodb.host=
+spring.data.mongodb.port=
 spring.data.mongodb.authentication-database=
 spring.data.mongodb.username=
 spring.data.mongodb.password=
 spring.data.mongodb.database=
 config.db.read-preference=primary
 db.collections.features.name=features
-db.collections.files.name=files
 db.collections.stats.name=populationStatistics
+# TODO The following 2 properties will be used exclusive after removing readers and writers dependency 
+# on OpenCGA. At the moment they need to be specified in both.
+db.collections.files.name=files
 db.collections.variants.name=variants
 
 
@@ -41,3 +44,4 @@ db.collections.variants.name=variants
 logging.level.uk.ac.ebi.eva=DEBUG
 logging.level.org.opencb.opencga=DEBUG
 logging.level.org.springframework=INFO
+

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobOptions.java
@@ -120,6 +120,7 @@ public class JobOptions {
     }
 
     private void loadDbConnectionOptions() throws IOException {
+        // TODO This block shall be removed when we use Spring Data parameters only
         URI configUri = URI.create(Config.getOpenCGAHome() + "/").resolve("conf/").resolve("storage-mongodb.properties");
         Properties properties = new Properties();
         properties.load(new InputStreamReader(new FileInputStream(configUri.getPath())));
@@ -145,6 +146,7 @@ public class JobOptions {
         if (dbCollectionFilesName == null) {
             dbCollectionFilesName = properties.getProperty(JobParametersNames.OPENCGA_DB_COLLECTIONS_FILES_NAME, "files");
         }
+        // TODO End of block to be removed when we use Spring Data parameters only
 
         if (dbHosts == null || dbHosts.isEmpty()) {
             throw new IllegalArgumentException("Please provide a database hostname");
@@ -169,6 +171,7 @@ public class JobOptions {
                 VariantStudy.StudyType.valueOf(studyType),
                 VariantSource.Aggregation.valueOf(aggregated));
 
+        // TODO This block shall be removed when we use Spring Data parameters only
         variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
         variantOptions.put(VariantStorageManager.OVERWRITE_STATS, overwriteStats);
         variantOptions.put(VariantStorageManager.INCLUDE_SRC, includeSourceLine);
@@ -181,6 +184,7 @@ public class JobOptions {
         variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_AUTHENTICATION_DB, dbAuthenticationDb);
         variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_USER, dbUser);
         variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_PASS, dbPassword);
+        // TODO End of block to be removed when we use Spring Data parameters only
 
         logger.debug("Using as input: {}", input);
         logger.debug("Using as variantOptions: {}", variantOptions.entrySet().toString());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobParametersNames.java
@@ -38,16 +38,16 @@ public class JobParametersNames {
 
 
     /*
-     * Database infrastructure (most parameters read from OpenCGA "conf" folder)
+     * Database infrastructure (Spring Data)
      */
     
-    public static final String CONFIG_DB_HOSTS = "config.db.hosts";
+    public static final String CONFIG_DB_HOSTS = "spring.data.mongodb.host";
     
-    public static final String CONFIG_DB_AUTHENTICATIONDB = "config.db.authentication-db";
+    public static final String CONFIG_DB_AUTHENTICATIONDB = "spring.data.mongodb.authentication-database";
     
-    public static final String CONFIG_DB_USER = "config.db.user";
+    public static final String CONFIG_DB_USER = "spring.data.mongodb.username";
     
-    public static final String CONFIG_DB_PASSWORD = "config.db.password";
+    public static final String CONFIG_DB_PASSWORD = "spring.data.mongodb.password";
     
     public static final String CONFIG_DB_READPREFERENCE = "config.db.read-preference";
     
@@ -56,7 +56,7 @@ public class JobParametersNames {
      * Database and collections
      */
     
-    public static final String DB_NAME = "db.name";
+    public static final String DB_NAME = "spring.data.mongodb.database";
     
     public static final String DB_COLLECTIONS_VARIANTS_NAME = "db.collections.variants.name";
     
@@ -79,7 +79,7 @@ public class JobParametersNames {
     
     
     /*
-     * OpenCGA
+     * OpenCGA (parameters read from OpenCGA "conf" folder)
      */
     
     public static final String APP_OPENCGA_PATH = "app.opencga.path";

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStep.java
@@ -185,8 +185,8 @@ public class PopulationStatisticsLoaderStep implements Tasklet {
                 QueryResult<?> writeResult = variantDBAdaptor.updateStats(statsBatch, options);
                 writes += writeResult.getNumResults();
                 logger.info("stats loaded up to position {}:{}", 
-                		statsBatch.get(statsBatch.size()-1).getChromosome(), 
-                		statsBatch.get(statsBatch.size()-1).getPosition());
+                            statsBatch.get(statsBatch.size()-1).getChromosome(),
+                            statsBatch.get(statsBatch.size()-1).getPosition());
                 statsBatch.clear();
             }
         }
@@ -195,8 +195,8 @@ public class PopulationStatisticsLoaderStep implements Tasklet {
             QueryResult<?> writeResult = variantDBAdaptor.updateStats(statsBatch, options);
             writes += writeResult.getNumResults();
             logger.info("stats loaded up to position {}:{}", 
-            		statsBatch.get(statsBatch.size()-1).getChromosome(), 
-            		statsBatch.get(statsBatch.size()-1).getPosition());
+                        statsBatch.get(statsBatch.size()-1).getChromosome(),
+                        statsBatch.get(statsBatch.size()-1).getPosition());
             statsBatch.clear();
         }
 

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -141,4 +141,8 @@ public class MongoDBHelper {
         return builder.toString();
     }
 
+    public static String buildStorageFileId(String studyId, String fileId) {
+        return studyId + "_" + fileId;
+    }
+
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/configuration/CommonConfiguration.java
@@ -50,10 +50,10 @@ public class CommonConfiguration {
 
         properties.put(JobParametersNames.STATISTICS_OVERWRITE, "false");
 
-        properties.put("db.hosts", "localhost:27017");
+        properties.put(JobParametersNames.CONFIG_DB_HOSTS, "localhost:27017");
 //        properties.put("dbName", null);
-        properties.put("db.collection.variants.name", "variants");
-        properties.put("db.collection.files.name", "files");
+        properties.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, "variants");
+        properties.put(JobParametersNames.DB_COLLECTIONS_FILES_NAME, "files");
         properties.put(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME, "features");
         properties.put(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME, "populationStatistics");
         properties.put(JobParametersNames.CONFIG_DB_READPREFERENCE, "primary");

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -117,8 +117,8 @@ public class PopulationStatisticsLoaderStepTest {
         String input = getResource(SMALL_VCF_FILE).getAbsolutePath();
         VariantSource source = new VariantSource(input, "4", "1", "studyName");
 
+        jobOptions.setDbName(mongoRule.getRandomTemporaryDatabaseName());
         jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, input);
-        jobOptions.getVariantOptions().put(VariantStorageManager.DB_NAME, mongoRule.getRandomTemporaryDatabaseName());
         jobOptions.getVariantOptions().put(VariantStorageManager.VARIANT_SOURCE, source);
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(PopulationStatisticsFlow.LOAD_STATISTICS);

--- a/src/test/resources/annotation-loader-step.properties
+++ b/src/test/resources/annotation-loader-step.properties
@@ -31,4 +31,4 @@ config.db.read-preference=primary
 
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=AnnotationLoaderStepTest
+spring.data.mongodb.database=AnnotationLoaderStepTest

--- a/src/test/resources/annotation.properties
+++ b/src/test/resources/annotation.properties
@@ -28,6 +28,6 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=VariantAnnotation
+spring.data.mongodb.database=VariantAnnotation
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics

--- a/src/test/resources/genotyped-vcf-workflow.properties
+++ b/src/test/resources/genotyped-vcf-workflow.properties
@@ -30,4 +30,4 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=GenotypedVcfWorkflowTest
+spring.data.mongodb.database=GenotypedVcfWorkflowTest

--- a/src/test/resources/genotyped-vcf.properties
+++ b/src/test/resources/genotyped-vcf.properties
@@ -30,4 +30,4 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=GenotypedVcfJobTest
+spring.data.mongodb.database=GenotypedVcfJobTest

--- a/src/test/resources/variant-aggregated.properties
+++ b/src/test/resources/variant-aggregated.properties
@@ -31,6 +31,6 @@ config.restartability.allow=false
 config.db.read-preference=primary
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics
-db.name=AggregatedJobTest
+spring.data.mongodb.database=AggregatedJobTest
 
 annotation.skip=true

--- a/src/test/resources/vep-input-generator-step.properties
+++ b/src/test/resources/vep-input-generator-step.properties
@@ -29,6 +29,6 @@ app.vep.num-forks=
 config.restartability.allow=false
 
 config.db.read-preference=primary
-db.name=VepInputGeneratorStepTest
+spring.data.mongodb.database=VepInputGeneratorStepTest
 db.collections.features.name=features
 db.collections.stats.name=populationStatistics


### PR DESCRIPTION
Using `spring.data.mongodb.*` parameters to provide database connection details to the pipeline. I couldn't find a way to select the read preference, but it is not very relevant to the pipeline anyway.

`PopulationStatisticsLoaderStep` refactored to remove dependencies on OpenCGA manager classes. This allows it to use said Spring Data parameters.