### PR TITLE
EVA-575 VariantVcfFactory: improve the memory usage by genotypes

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactory.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactory.java
@@ -98,7 +98,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 
     @Override
     protected void parseSplitSampleData(Variant variant, VariantSource source, String[] fields,
-                                        String[] alternateAlleles, String[] secondaryAlternates, int alleleIdx)
+                                        String[] alternateAlleles, String[] secondaryAlternates, int alternateAlleleIdx)
             throws NonStandardCompliantSampleField {
         // Nothing to do
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
@@ -124,7 +124,7 @@ public class VariantVcfFactory {
             variant.addSourceEntry(file);
 
             try {
-                parseSplitSampleData(variant, source, fields, alternateAlleles, secondaryAlternates, i + 1);
+                parseSplitSampleData(variant, source, fields, alternateAlleles, secondaryAlternates, i);
                 // Fill the rest of fields (after samples because INFO depends on them)
                 setOtherFields(variant, source, ids, quality, filter, info, format, keyFields.getNumAllele(),
                                alternateAlleles, line);
@@ -271,7 +271,7 @@ public class VariantVcfFactory {
      * If this is a field other than the genotype (GT), return unmodified.
      *
      * If this field is the genotype (GT) then, intern it into the String pool to avoid storing lots of "0/0". In case
-     * that the variant is multiallelic and we are currently processing one of the secondary alternates (alleleIdx >=2),
+     * that the variant is multiallelic and we are currently processing one of the secondary alternates (alleleIdx >=1),
      * change the allele codes to represent the current alternate as allele 1. {@see mapToMultiallelicIndex}
      *
      * @param alleleIdx current alternate being processed. 1 for first alternate, 2 or more for a secondary alternate.
@@ -281,7 +281,7 @@ public class VariantVcfFactory {
      */
     private String processSampleField(int alleleIdx, String formatField, String sampleField) {
         if (formatField.equalsIgnoreCase("GT")) {
-            if (alleleIdx >= 2) {
+            if (alleleIdx >= 1) {
                 Genotype genotype = new Genotype(sampleField);
 
                 StringBuilder genotypeStr = new StringBuilder();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
@@ -16,10 +16,7 @@
  */
 package uk.ac.ebi.eva.pipeline.io.mappers;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.opencb.biodata.models.feature.AllelesCode;
-import org.opencb.biodata.models.feature.Genotype;
 import org.opencb.biodata.models.variant.VariantFactory;
 import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.biodata.models.variant.exceptions.NonStandardCompliantSampleField;
@@ -30,12 +27,12 @@ import uk.ac.ebi.eva.commons.models.data.VariantSourceEntry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,17 +45,17 @@ public class VariantVcfFactory {
      * Creates a list of Variant objects using the fields in a record of a VCF
      * file. A new Variant object is created per allele, so several of them can
      * be created from a single line.
-     * 
-     * Start/end coordinates assignment tries to work as similarly as possible 
-     * as Ensembl does, except for insertions, where start is greater than end: 
+     * <p>
+     * Start/end coordinates assignment tries to work as similarly as possible
+     * as Ensembl does, except for insertions, where start is greater than end:
      * http://www.ensembl.org/info/docs/tools/vep/vep_formats.html#vcf
      *
      * @param source context of the variant: studyId, fileId, etc
      * @param line Contents of the line in the file
-     * @return The list of Variant objects that can be created using the fields
-     * from a VCF record
+     * @return The list of Variant objects that can be created using the fields from a VCF record
      */
-    public List<Variant> create(VariantSource source, String line) throws IllegalArgumentException, NotAVariantException {
+    public List<Variant> create(VariantSource source,
+                                String line) throws IllegalArgumentException, NotAVariantException {
         String[] fields = line.split("\t");
         if (fields.length < 8) {
             throw new IllegalArgumentException("Not enough fields provided (min 8)");
@@ -76,10 +73,10 @@ public class VariantVcfFactory {
 
         String reference = fields[3].equals(".") ? "" : fields[3];
         String alternate = fields[4];
-        if(fields[4].equals(".")) {
+        if (fields[4].equals(".")) {
             throw new NotAVariantException(
                     "Alternative allele is a '.'. This is not an actual variant but a reference position. Variant found as: "
-                    + chromosome + ":" + position + ":" + reference + ">" + alternate);
+                            + chromosome + ":" + position + ":" + reference + ">" + alternate);
         }
 //        String alternate = fields[4].equals(".") ? "" : fields[4];
         String[] alternateAlleles = alternate.split(",");
@@ -90,8 +87,7 @@ public class VariantVcfFactory {
 
         List<VariantKeyFields> generatedKeyFields = new ArrayList<>();
 
-        for (int i = 0; i < alternateAlleles.length; i++) {
-            // This 'i' index is necessary to get the samples where the mutated allele is present
+        for (int i = 0; i < alternateAlleles.length; i++) { // This index is necessary for getting the samples where the mutated allele is present
             String alt = alternateAlleles[i];
             VariantKeyFields keyFields;
             int referenceLen = reference.length();
@@ -119,7 +115,8 @@ public class VariantVcfFactory {
         // Now create all the Variant objects read from the VCF record
         for (int i = 0; i < alternateAlleles.length; i++) {
             VariantKeyFields keyFields = generatedKeyFields.get(i);
-            Variant variant = new Variant(chromosome, keyFields.start, keyFields.end, keyFields.reference, keyFields.alternate);
+            Variant variant = new Variant(chromosome, keyFields.start, keyFields.end, keyFields.reference,
+                                          keyFields.alternate);
             String[] secondaryAlternates = getSecondaryAlternates(variant, keyFields.getNumAllele(), alternateAlleles);
             VariantSourceEntry file = new VariantSourceEntry(source.getFileId(), source.getStudyId(),
                                                              secondaryAlternates, format);
@@ -132,9 +129,10 @@ public class VariantVcfFactory {
                                alternateAlleles, line);
                 variants.add(variant);
             } catch (NonStandardCompliantSampleField ex) {
-                Logger.getLogger(VariantFactory.class.getName()).log(Level.SEVERE,
-                        String.format("Variant %s:%d:%s>%s will not be saved\n%s",
-                                chromosome, position, reference, alternateAlleles[i], ex.getMessage()));
+                Logger.getLogger(VariantFactory.class.getName())
+                      .log(Level.SEVERE,
+                           String.format("Variant %s:%d:%s>%s will not be saved\n%s", chromosome, position, reference,
+                                         alternateAlleles[i], ex.getMessage()));
             }
         }
 
@@ -142,12 +140,12 @@ public class VariantVcfFactory {
     }
 
     /**
-     * Calculates the start, end, reference and alternate of a SNV/MNV where the 
-     * reference and the alternate are not empty. 
-     * 
-     * This task comprises 2 steps: removing the trailing bases that are 
+     * Calculates the start, end, reference and alternate of a SNV/MNV where the
+     * reference and the alternate are not empty.
+     * <p>
+     * This task comprises 2 steps: removing the trailing bases that are
      * identical in both alleles, then the leading identical bases.
-     * 
+     *
      * @param position Input starting position
      * @param reference Input reference allele
      * @param alt Input alternate allele
@@ -159,10 +157,10 @@ public class VariantVcfFactory {
         String refReversed = StringUtils.reverse(reference);
         String altReversed = StringUtils.reverse(alt);
         indexOfDifference = StringUtils.indexOfDifference(refReversed, altReversed);
-        
+
         reference = StringUtils.reverse(refReversed.substring(indexOfDifference));
         alt = StringUtils.reverse(altReversed.substring(indexOfDifference));
-        
+
         // Remove the leading bases
         indexOfDifference = StringUtils.indexOfDifference(reference, alt);
         if (indexOfDifference < 0) {
@@ -185,12 +183,12 @@ public class VariantVcfFactory {
     }
 
     /**
-     * Calculates the start, end, reference and alternate of an indel where the 
-     * reference and the alternate are not empty. 
-     * 
-     * This task comprises 2 steps: removing the trailing bases that are 
+     * Calculates the start, end, reference and alternate of an indel where the
+     * reference and the alternate are not empty.
+     * <p>
+     * This task comprises 2 steps: removing the trailing bases that are
      * identical in both alleles, then the leading identical bases.
-     * 
+     *
      * @param position Input starting position
      * @param reference Input reference allele
      * @param alt Input alternate allele
@@ -202,10 +200,10 @@ public class VariantVcfFactory {
         String refReversed = StringUtils.reverse(reference);
         String altReversed = StringUtils.reverse(alt);
         indexOfDifference = StringUtils.indexOfDifference(refReversed, altReversed);
-        
+
         reference = StringUtils.reverse(refReversed.substring(indexOfDifference));
         alt = StringUtils.reverse(altReversed.substring(indexOfDifference));
-        
+
         // Remove the leading bases
         indexOfDifference = StringUtils.indexOfDifference(reference, alt);
         if (indexOfDifference < 0) {
@@ -234,7 +232,7 @@ public class VariantVcfFactory {
     }
 
     protected String[] getSecondaryAlternates(Variant variant, int numAllele, String[] alternateAlleles) {
-        String[] secondaryAlternates = new String[alternateAlleles.length-1];
+        String[] secondaryAlternates = new String[alternateAlleles.length - 1];
         for (int i = 0, j = 0; i < alternateAlleles.length; i++) {
             if (i != numAllele) {
                 secondaryAlternates[j++] = alternateAlleles[i];
@@ -243,82 +241,22 @@ public class VariantVcfFactory {
         return secondaryAlternates;
     }
 
-    protected void parseSplitSampleData(Variant variant, VariantSource source, String[] fields, 
-            String[] alternateAlleles, String[] secondaryAlternates, int alleleIdx)
-                    throws NonStandardCompliantSampleField {
+    protected void parseSplitSampleData(Variant variant, VariantSource source, String[] fields,
+                                        String[] alternateAlleles, String[] secondaryAlternates,
+                                        int alleleIdx) throws NonStandardCompliantSampleField {
         String[] formatFields = variant.getSourceEntry(source.getFileId(), source.getStudyId()).getFormat().split(":");
 
         for (int i = 9; i < fields.length; i++) {
-            Map<String, String> map = new HashMap<>(5);
+            Map<String, String> map = new TreeMap<>();
 
             // Fill map of a sample
             String[] sampleFields = fields[i].split(":");
-            Genotype genotype = null;
 
             // Samples may remove the trailing fields (only GT is mandatory),
             // so the loop iterates to sampleFields.length, not formatFields.length
             for (int j = 0; j < sampleFields.length; j++) {
                 String formatField = formatFields[j];
-                String sampleField = sampleFields[j];
-
-                if (formatField.equalsIgnoreCase("GT")) {
-                    // Save alleles just in case they are necessary for GL/PL/GP transformation
-                    genotype = new Genotype(sampleField, variant.getReference(), variant.getAlternate());
-
-                    StringBuilder genotypeStr = new StringBuilder();
-                    for (int allele : genotype.getAllelesIdx()) {
-                        if (allele == 0) { // Reference
-                            genotypeStr.append("0");
-                        } else if (allele == alleleIdx) { // Current alternate
-                            genotypeStr.append("1");
-                        } else if (allele < 0) { // Missing
-                            genotypeStr.append(".");
-                        } else {
-                            // Replace numerical indexes when they refer to another alternate allele
-                            genotypeStr.append(String.valueOf(ArrayUtils.indexOf(secondaryAlternates,
-                                                                                 alternateAlleles[allele-1]) + 2));
-                        }
-                        genotypeStr.append(genotype.isPhased() ? "|" : "/");
-                    }
-                    sampleField = genotypeStr.substring(0, genotypeStr.length()-1);
-                        
-                } else if (formatField.equalsIgnoreCase("GL")
-                        || formatField.equalsIgnoreCase("PL")
-                        || formatField.equalsIgnoreCase("GP")) {
-                    // All-alleles present and not haploid
-                    if (!sampleField.equals(".") && genotype != null
-                            && (genotype.getCode() == AllelesCode.ALLELES_OK
-                            || genotype.getCode() == AllelesCode.MULTIPLE_ALTERNATES)) {
-                        String[] likelihoods = sampleField.split(",");
-
-                        // If only 3 likelihoods are represented, no transformation is needed
-                        if (likelihoods.length > 3) {
-                            // Get alleles index to work with: if both are the same alternate,
-                            // the combinations must be run with the reference allele.
-                            // Otherwise all GL reported would be alt/alt.
-                            int allele1 = genotype.getAllele(0);
-                            int allele2 = genotype.getAllele(1);
-                            if (genotype.getAllele(0) == genotype.getAllele(1) && genotype.getAllele(0) > 0) {
-                                allele1 = 0;
-                            }
-
-                            // If the number of values is not enough for this GT
-                            int maxAllele = allele1 >= allele2 ? allele1 : allele2;
-                            int numValues = (int) (((float) maxAllele * (maxAllele + 1)) / 2) + maxAllele;
-                            if (likelihoods.length < numValues) {
-                                throw new NonStandardCompliantSampleField(
-                                    formatField, sampleField, String.format("It must contain %d values", numValues));
-                            }
-
-                            // Genotype likelihood must be distributed following similar criteria as genotypes
-                            String[] alleleLikelihoods = new String[3];
-                            alleleLikelihoods[0] = likelihoods[(int) (((float) allele1 * (allele1 + 1)) / 2) + allele1];
-                            alleleLikelihoods[1] = likelihoods[(int) (((float) allele2 * (allele2 + 1)) / 2) + allele1];
-                            alleleLikelihoods[2] = likelihoods[(int) (((float) allele2 * (allele2 + 1)) / 2) + allele2];
-                            sampleField = StringUtils.join(alleleLikelihoods, ",");
-                        }
-                    }
-                }
+                String sampleField = "GT".equals(formatField) ? sampleFields[j].intern() : sampleFields[j];
 
                 map.put(formatField, sampleField);
             }
@@ -328,41 +266,14 @@ public class VariantVcfFactory {
         }
     }
 
-    /**
-     * Checks whether a sample should be included in a variant's list of
-     * samples. If current allele index is not found in the genotype and not all
-     * alleles are references/missing, then the sample must not be included.
-     *
-     * @param genotype The genotype
-     * @param alleleIdx The index of the allele
-     * @return If the sample should be associated to the variant
-     */
-    private boolean shouldAddSampleToVariant(String genotype, int alleleIdx) {
-        if (genotype.contains(String.valueOf(alleleIdx))) {
-            return true;
-        }
-        
-        if (!genotype.contains("0") && !genotype.contains(".")) {
-            return false;
-        }
-        
-        String[] alleles = genotype.split("[/|]");
-        for (String allele : alleles) {
-            if (!allele.equals("0") && !allele.equals(".")) {
-                return false;
-            }
-        }
-        
-        return true;
-    }
-
     protected void setOtherFields(Variant variant, VariantSource source, Set<String> ids, float quality, String filter,
-            String info, String format, int numAllele, String[] alternateAlleles, String line) {
+                                  String info, String format, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
 
         if (quality > -1) {
-            variant.getSourceEntry(source.getFileId(), source.getStudyId()).addAttribute("QUAL", String.valueOf(quality));
+            variant.getSourceEntry(source.getFileId(), source.getStudyId())
+                   .addAttribute("QUAL", String.valueOf(quality));
         }
         if (!filter.isEmpty()) {
             variant.getSourceEntry(source.getFileId(), source.getStudyId()).addAttribute("FILTER", filter);
@@ -375,7 +286,7 @@ public class VariantVcfFactory {
 
     protected void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele) {
         VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
-        
+
         for (String var : info.split(";")) {
             String[] splits = var.split("=");
             if (splits.length == 2) {
@@ -443,6 +354,7 @@ public class VariantVcfFactory {
     protected class VariantKeyFields {
 
         int start, end, numAllele;
+
         String reference, alternate;
 
         public VariantKeyFields(int start, int end, String reference, String alternate) {
@@ -462,21 +374,21 @@ public class VariantVcfFactory {
     }
 
     /**
-     * In multiallelic variants, we have a list of alternates, where numAllele is the one whose variant we are parsing now.
-     * If we are parsing the first variant (numAllele == 0) A1 refers to first alternative, (i.e. alternateAlleles[0]),
-     * A2 to second alternative (alternateAlleles[1]), and so on.
-     * However, if numAllele == 1, A1 refers to second alternate (alternateAlleles[1]), A2 to first (alternateAlleles[0])
-     * and higher alleles remain unchanged.
-     * Moreover, if NumAllele == 2, A1 is third alternate, A2 is first alternate and A3 is second alternate.
+     * In multiallelic variants, we have a list of alternates, where numAllele is the one whose variant we are parsing
+     * now. If we are parsing the first variant (numAllele == 0) A1 refers to first alternative, (i.e.
+     * alternateAlleles[0]), A2 to second alternative (alternateAlleles[1]), and so on. However, if numAllele == 1, A1
+     * refers to second alternate (alternateAlleles[1]), A2 to first (alternateAlleles[0]) and higher alleles remain
+     * unchanged. Moreover, if NumAllele == 2, A1 is third alternate, A2 is first alternate and A3 is second alternate.
      * It's also assumed that A0 would be the reference, so it remains unchanged too.
+     * <p>
+     * This pattern of the first allele moving along (and swapping) is what describes this function. Also, look
+     * VariantVcfFactory.getSecondaryAlternates().
      *
-     * This pattern of the first allele moving along (and swapping) is what describes this function. 
-     * Also, look VariantVcfFactory.getSecondaryAlternates().
      * @param parsedAllele the value of parsed alleles. e.g. 1 if genotype was "A1" (first allele).
      * @param numAllele current variant of the alternates.
      * @return the correct allele index depending on numAllele.
      */
-    protected static int mapToMultiallelicIndex (int parsedAllele, int numAllele) {
+    protected static int mapToMultiallelicIndex(int parsedAllele, int numAllele) {
         int correctedAllele = parsedAllele;
         if (parsedAllele > 0) {
             if (parsedAllele == numAllele + 1) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactoryTest.java
@@ -1,0 +1,108 @@
+package org.opencb.biodata.models.variant;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opencb.biodata.models.feature.Genotype;
+import org.opencb.biodata.models.variant.stats.VariantStats;
+import org.opencb.commons.test.GenericTest;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+
+/** 
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class VariantAggregatedVcfFactoryTest extends GenericTest {
+    private VariantSource source = new VariantSource("filename.vcf", "fileId", "studyId", "studyName");
+    private VariantAggregatedVcfFactory factory = new VariantAggregatedVcfFactory();
+    
+    @Test
+    public void parseAC_AN() {
+        String line = "1\t54722\t.\tTTC\tT,TCTC\t999\tPASS\tDP4=3122,3282,891,558;DP=22582;INDEL;IS=3,0.272727;VQSLOD=6.76;AN=3854;AC=889,61;TYPE=del,ins;HWE=0;ICF=-0.155251";   // structure like uk10k
+
+        List<Variant> variants = factory.create(source, line);
+        
+        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
+        assertEquals(2904, stats.getRefAlleleCount());
+        assertEquals(889, stats.getAltAlleleCount());
+        
+        stats = variants.get(1).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
+        assertEquals(2904, stats.getRefAlleleCount());
+        assertEquals(61, stats.getAltAlleleCount());
+        assertEquals(0.015827711, stats.getMaf(), 0.0001);
+    }
+    
+    @Test
+    public void parseGTC () {
+        String line = "20\t61098\trs6078030\tC\tT\t51254.56\tPASS\tAC=225;AN=996;GTC=304,163,31";   // structure like gonl
+
+        List<Variant> variants = factory.create(source, line);
+
+        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
+        assertEquals(new Integer(304), stats.getGenotypesCount().get(new Genotype("0/0", "C", "T")));
+        assertEquals(new Integer(163), stats.getGenotypesCount().get(new Genotype("0/1", "C", "T")));
+        assertEquals(new Integer(31),  stats.getGenotypesCount().get(new Genotype("T/T", "C", "T")));
+        assertEquals(0.225903614, stats.getMaf(), 0.0001);
+    }
+    
+    @Test
+    public void parseCustomGTC () {
+        String line = "1\t1225579\t.\tG\tA,C\t170.13\tPASS\tAC=3,8;AN=534;AF=0.006,0.015;HPG_GTC=0/0:258,0/1:1,0/2:6,1/1:1,1/2:0,2/2:1,./.:0";  // structure like HPG
+
+        Properties properties = new Properties();
+        properties.put("ALL.GTC", "HPG_GTC");
+        properties.put("ALL.AC", "AC");
+        properties.put("ALL.AN", "AN");
+        properties.put("ALL.AF", "AF");
+        List<Variant> variants = new VariantAggregatedVcfFactory(properties).create(source, line);
+
+        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getCohortStats("ALL");
+        assertEquals(523, stats.getRefAlleleCount());
+        assertEquals(3, stats.getAltAlleleCount());
+        assertEquals(0.006, stats.getAltAlleleFreq(), 0.0001);
+        assertEquals(3.0/534, stats.getMaf(), 0.0001);
+        assertEquals(new Integer(258), stats.getGenotypesCount().get(new Genotype("0/0", "G", "A")));
+        assertEquals(new Integer(1), stats.getGenotypesCount().get(new Genotype("0/1", "G", "A")));
+        assertEquals(new Integer(1), stats.getGenotypesCount().get(new Genotype("A/A", "G", "A")));
+        assertEquals(new Integer(6), stats.getGenotypesCount().get(new Genotype("0/2", "G", "A")));
+        assertEquals(new Integer(0), stats.getGenotypesCount().get(new Genotype("./.", "G", "A")));
+        
+        stats = variants.get(1).getSourceEntry(source.getFileId(), source.getStudyId()).getCohortStats("ALL");
+        assertEquals(new Integer(6), stats.getGenotypesCount().get(new Genotype("0/1", "G", "C")));
+        
+    }
+    
+    @Test
+    public void parseWithGTS () {
+        String line = "1\t861255\t.\tA\tG\t.\tPASS\tAC=2;AF=0.0285714285714286;AN=70;GTS=GG,GA,AA;GTC=1,0,34";
+
+        List<Variant> variants = factory.create(source, line);
+
+        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
+        assertEquals(new Integer(34), stats.getGenotypesCount().get(new Genotype("0/0", "A", "G")));
+        assertEquals(new Integer(0),  stats.getGenotypesCount().get(new Genotype("0/1", "A", "G")));
+        assertEquals(new Integer(1),  stats.getGenotypesCount().get(new Genotype("G/G", "A", "G")));
+        assertEquals(2.0/70, stats.getMaf(), 0.0001);
+    }
+    
+    @Test
+    public void getGenotype() {
+        for (int i = 0; i < 11; i++) {
+            Integer alleles[] = new Integer[2];
+            VariantAggregatedVcfFactory.getGenotype(i, alleles);
+            System.out.println("alleles[" + i + "] = " + alleles[0] + "/" + alleles[1]);
+        }
+
+        Integer alleles[] = new Integer[2];
+        VariantAggregatedVcfFactory.getGenotype(0, alleles);    // 0/0
+        assertEquals(alleles[0], alleles[1]);
+        VariantAggregatedVcfFactory.getGenotype(2, alleles);    // 1/1
+        assertEquals(alleles[0], alleles[1]);
+        VariantAggregatedVcfFactory.getGenotype(5, alleles);    // 2/2
+        assertEquals(alleles[0], alleles[1]);
+        assertEquals(alleles[0], new Integer(2));
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantAggregatedVcfFactoryTest.java
@@ -1,42 +1,62 @@
-package org.opencb.biodata.models.variant;
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.io.mappers;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opencb.biodata.models.feature.Genotype;
-import org.opencb.biodata.models.variant.stats.VariantStats;
+import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.commons.test.GenericTest;
+
+import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.commons.models.data.VariantStats;
 
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
-/** 
- * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+/**
+ * {@link VariantAggregatedVcfFactory}
+ * input: a generic aggregated VCF
+ * output: a List of Variants
  */
 public class VariantAggregatedVcfFactoryTest extends GenericTest {
     private VariantSource source = new VariantSource("filename.vcf", "fileId", "studyId", "studyName");
+
     private VariantAggregatedVcfFactory factory = new VariantAggregatedVcfFactory();
-    
+
     @Test
     public void parseAC_AN() {
         String line = "1\t54722\t.\tTTC\tT,TCTC\t999\tPASS\tDP4=3122,3282,891,558;DP=22582;INDEL;IS=3,0.272727;VQSLOD=6.76;AN=3854;AC=889,61;TYPE=del,ins;HWE=0;ICF=-0.155251";   // structure like uk10k
 
         List<Variant> variants = factory.create(source, line);
-        
+
         VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
         assertEquals(2904, stats.getRefAlleleCount());
         assertEquals(889, stats.getAltAlleleCount());
-        
+
         stats = variants.get(1).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
         assertEquals(2904, stats.getRefAlleleCount());
         assertEquals(61, stats.getAltAlleleCount());
         assertEquals(0.015827711, stats.getMaf(), 0.0001);
     }
-    
+
     @Test
-    public void parseGTC () {
+    public void parseGTC() {
         String line = "20\t61098\trs6078030\tC\tT\t51254.56\tPASS\tAC=225;AN=996;GTC=304,163,31";   // structure like gonl
 
         List<Variant> variants = factory.create(source, line);
@@ -44,12 +64,12 @@ public class VariantAggregatedVcfFactoryTest extends GenericTest {
         VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
         assertEquals(new Integer(304), stats.getGenotypesCount().get(new Genotype("0/0", "C", "T")));
         assertEquals(new Integer(163), stats.getGenotypesCount().get(new Genotype("0/1", "C", "T")));
-        assertEquals(new Integer(31),  stats.getGenotypesCount().get(new Genotype("T/T", "C", "T")));
+        assertEquals(new Integer(31), stats.getGenotypesCount().get(new Genotype("T/T", "C", "T")));
         assertEquals(0.225903614, stats.getMaf(), 0.0001);
     }
-    
+
     @Test
-    public void parseCustomGTC () {
+    public void parseCustomGTC() {
         String line = "1\t1225579\t.\tG\tA,C\t170.13\tPASS\tAC=3,8;AN=534;AF=0.006,0.015;HPG_GTC=0/0:258,0/1:1,0/2:6,1/1:1,1/2:0,2/2:1,./.:0";  // structure like HPG
 
         Properties properties = new Properties();
@@ -57,37 +77,39 @@ public class VariantAggregatedVcfFactoryTest extends GenericTest {
         properties.put("ALL.AC", "AC");
         properties.put("ALL.AN", "AN");
         properties.put("ALL.AF", "AF");
-        List<Variant> variants = new VariantAggregatedVcfFactory(properties).create(source, line);
+        List<Variant> variants = new VariantAggregatedVcfFactory(properties).create(
+                source, line);
 
-        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getCohortStats("ALL");
+        VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getCohortStats(
+                "ALL");
         assertEquals(523, stats.getRefAlleleCount());
         assertEquals(3, stats.getAltAlleleCount());
         assertEquals(0.006, stats.getAltAlleleFreq(), 0.0001);
-        assertEquals(3.0/534, stats.getMaf(), 0.0001);
+        assertEquals(3.0 / 534, stats.getMaf(), 0.0001);
         assertEquals(new Integer(258), stats.getGenotypesCount().get(new Genotype("0/0", "G", "A")));
         assertEquals(new Integer(1), stats.getGenotypesCount().get(new Genotype("0/1", "G", "A")));
         assertEquals(new Integer(1), stats.getGenotypesCount().get(new Genotype("A/A", "G", "A")));
         assertEquals(new Integer(6), stats.getGenotypesCount().get(new Genotype("0/2", "G", "A")));
         assertEquals(new Integer(0), stats.getGenotypesCount().get(new Genotype("./.", "G", "A")));
-        
+
         stats = variants.get(1).getSourceEntry(source.getFileId(), source.getStudyId()).getCohortStats("ALL");
         assertEquals(new Integer(6), stats.getGenotypesCount().get(new Genotype("0/1", "G", "C")));
-        
+
     }
-    
+
     @Test
-    public void parseWithGTS () {
+    public void parseWithGTS() {
         String line = "1\t861255\t.\tA\tG\t.\tPASS\tAC=2;AF=0.0285714285714286;AN=70;GTS=GG,GA,AA;GTC=1,0,34";
 
         List<Variant> variants = factory.create(source, line);
 
         VariantStats stats = variants.get(0).getSourceEntry(source.getFileId(), source.getStudyId()).getStats();
         assertEquals(new Integer(34), stats.getGenotypesCount().get(new Genotype("0/0", "A", "G")));
-        assertEquals(new Integer(0),  stats.getGenotypesCount().get(new Genotype("0/1", "A", "G")));
-        assertEquals(new Integer(1),  stats.getGenotypesCount().get(new Genotype("G/G", "A", "G")));
-        assertEquals(2.0/70, stats.getMaf(), 0.0001);
+        assertEquals(new Integer(0), stats.getGenotypesCount().get(new Genotype("0/1", "A", "G")));
+        assertEquals(new Integer(1), stats.getGenotypesCount().get(new Genotype("G/G", "A", "G")));
+        assertEquals(2.0 / 70, stats.getMaf(), 0.0001);
     }
-    
+
     @Test
     public void getGenotype() {
         for (int i = 0; i < 11; i++) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfEVSFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfEVSFactoryTest.java
@@ -1,0 +1,365 @@
+package org.opencb.biodata.models.variant;
+
+import org.junit.Test;
+import org.opencb.biodata.models.feature.Genotype;
+import org.opencb.commons.test.GenericTest;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Alejandro Aleman Ramos &lt;aaleman@cipf.es&gt;
+ * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class VariantVcfEVSFactoryTest extends GenericTest {
+
+    private VariantSource source = new VariantSource("EVS", "EVS", "EVS", "EVS");
+    private VariantFactory factory = new VariantVcfEVSFactory();
+
+    @Test
+    public void testCreate_AA_AC_TT_GT() throws Exception { // AA,AC,TT,GT,...
+
+        String line="1\t69428\trs140739101\tT\tG\t.\tPASS\tMAF=4.5707,0.3663,3.0647;GTS=GG,GT,TT;GTC=93,141,5101";
+
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 1);
+
+        Variant v = res.get(0);
+        VariantSourceEntry avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("0/0","T","G"), 5101);
+        genotypes.put(new Genotype("0/1","T","G"), 141);
+        genotypes.put(new Genotype("1/1","T","G"), 93);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+
+    }
+
+    @Test
+    public void testCreate_A_C_T_G(){ // A,C,T,G
+
+        String line = "Y\t25375759\trs373156833\tT\tA\t.\tPASS\tMAF=0.0,0.1751,0.0409;GTS=A,T;GTC=1,2442";
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 1);
+
+        Variant v = res.get(0);
+        VariantSourceEntry avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("0/0", "T", "A"), 2442);
+        genotypes.put(new Genotype("1/1", "T", "A"), 1);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+
+    }
+
+    @Test
+    public void testCreate_R_RR_A1R_A1A1(){ // R, RR, A1R, A1A1
+        String line  ="X\t100117423\t.\tAG\tA\t.\tPASS\tMAF=0.0308,0.0269,0.0294;GTS=A1A1,A1R,RR,R;GTC=1,1,3947,2306;";
+
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 1);
+
+        Variant v = res.get(0);
+
+        assertEquals(v.getReference(), "G");
+        assertEquals(v.getAlternate(), "");
+
+
+        VariantSourceEntry avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("1/1", "G", ""), 1);
+        genotypes.put(new Genotype("0/1", "G", ""), 1);
+        genotypes.put(new Genotype("0/0", "G", ""), 6253);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+
+    }
+
+    @Test
+    public void testCreate_R_RR_A1A1_A1R_A1(){ // A1,A2,A3
+        String line = "X\t106362078\trs3216052\tCT\tC\t.\tPASS\tMAF=18.1215,25.2889,38.7555;GTS=A1A1,A1R,A1,RR,R;GTC=960,1298,737,1691,1570";
+
+
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 1);
+
+        Variant v = res.get(0);
+
+        assertEquals(v.getReference(), "T");
+        assertEquals(v.getAlternate(), "");
+
+
+        VariantSourceEntry avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("1/1", "T", ""), 1697);
+        genotypes.put(new Genotype("0/1", "T", ""), 1298);
+        genotypes.put(new Genotype("0/0", "T", ""), 3261);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+    }
+
+    @Test
+    public void testCreate_A1A1_A1A2_A2R_A2_RR_R(){// A1A2,A1A3...
+
+        String line = "X\t14039552\t.\tCA\tCAA,C\t.\tPASS\tMAF=5.3453,4.2467,4.9459;GTS=A1A1,A1A2,A1R,A1,A2A2,A2R,A2,RR,R;GTC=0,0,134,162,4,92,107,3707,2027;";
+
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 2);
+
+        Variant v = res.get(0);
+
+        assertEquals(v.getReference(), "");
+        assertEquals(v.getAlternate(), "A");
+
+
+        VariantSourceEntry avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("1/1", "", "A"), 162);
+        genotypes.put(new Genotype("1/2", "", "A"), 0);
+        genotypes.put(new Genotype("0/1", "", "A"), 134);
+        genotypes.put(new Genotype("0/0", "", "A"), 5734);
+        genotypes.put(new Genotype("2/2", "", "A"), 111);
+        genotypes.put(new Genotype("0/2", "", "A"), 92);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+
+
+        v = res.get(1);
+
+        assertEquals(v.getReference(), "A");
+        assertEquals(v.getAlternate(), "");
+
+
+        avf = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("1/1", "A", ""), 111);
+        genotypes.put(new Genotype("1/2", "A", ""), 0);
+        genotypes.put(new Genotype("0/1", "A", ""), 92);
+        genotypes.put(new Genotype("0/0", "A", ""), 5734);
+        genotypes.put(new Genotype("2/2", "A", ""), 162);
+        genotypes.put(new Genotype("0/2", "A", ""), 134);
+
+        assertEquals(avf.getStats().getGenotypesCount(), genotypes);
+
+
+    }
+
+    /**
+     * This tests the population values for MAF, AC and GTC, both for INDELs and SNVs
+     */
+    @Test
+    public void testPopulation() {
+        // ------------- INDEL
+        String line = "21\t9908404\t.\tTG\tT\t.\tPASS\tDBSNP=.;EA_AC=1,3849;AA_AC=2,2120;TAC=3,5969;MAF=0.026,0.0943,0.0502;GTS=A1A1,A1R,RR;EA_GTC=0,1,1924;AA_GTC=0,2,1059;GTC=0,3,2983;DP=17;GL=.;CP=0.1;CG=0.1;AA=.;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=intergenic;HGVS_CDNA_VAR=.;HGVS_PROTEIN_VAR=.;CDS_SIZES=.;GS=.;PH=.;EA_AGE=.;AA_AGE=.";
+        Properties properties = new Properties();
+        properties.put("EA.AC", "EA_AC");
+        properties.put("EA.GTC", "EA_GTC");
+        properties.put("AA.AC", "AA_AC");
+        properties.put("AA.GTC", "AA_GTC");
+        properties.put("ALL.AC", "TAC");
+        properties.put("ALL.GTC", "ALL_GTC");
+        properties.put("GROUPS_ORDER", "EA,AA,ALL");
+        VariantFactory evsFactory = new VariantVcfEVSFactory(properties);
+        
+        List<Variant> res = evsFactory.create(source, line);
+        
+        // Allele count
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getAltAlleleCount(), 1);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getRefAlleleCount(), 3849);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getAltAlleleCount(), 3);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getRefAlleleCount(), 5969);
+
+        // MAF
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getMaf(), 0.026 / 100, 0.000001);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getMaf(), 0.0943 / 100, 0.000001);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getMaf(), 0.0502 / 100, 0.000001);
+        
+        // GTC
+        List<Genotype> genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "G", ""));
+        genotypes.add(new Genotype("0/1", "G", ""));
+        genotypes.add(new Genotype("0/0", "G", ""));
+        List<Integer> counts = new ArrayList<>(Arrays.asList(0, 1, 1924));
+        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+        
+        
+        // -------------- SNV, (GTS are expressed in another way)
+        line = "21\t10862547\trs373689868\tG\tA\t.\tPASS\tDBSNP=dbSNP_138;EA_AC=0,3182;AA_AC=6,1378;TAC=6,4560;MAF=0.0,0.4335,0.1314;GTS=AA,AG,GG;EA_GTC=0,0,1591;AA_GTC=0,6,686;GTC=0,6,2277;DP=93;GL=.;CP=0.0;CG=-1.5;AA=G;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=intergenic;HGVS_CDNA_VAR=.;HGVS_PROTEIN_VAR=.;CDS_SIZES=.;GS=.;PH=.;EA_AGE=.;AA_AGE=.";
+
+        res = evsFactory.create(source, line);
+        
+        genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "G", "A"));
+        genotypes.add(new Genotype("0/1", "G", "A"));
+        genotypes.add(new Genotype("0/0", "G", "A"));
+        counts = new ArrayList<>(Arrays.asList(0, 6, 686));
+        genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getGenotypesCount();
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+    }
+
+    /**
+     * this tests the population stats AC and GTC for multiallelic variants, both for INDELs and SNVs
+     */
+    @Test
+    public void testPopulationMultiallelic() {
+        String line = "21\t47976819\t.\tCTT\tCTTT,C,CT\t.\tPASS\tDBSNP=.;EA_AC=393,35,531,6861;AA_AC=172,13,221,3174;TAC=565,48,752,10035;MAF=12.2634,11.3408,11.9737;GTS=A1A1,A1A2,A1A3,A1R,A2A2,A2A3,A2R,A3A3,A3R,RR;EA_GTC=1,2,3,4,5,6,7,8,9,10;AA_GTC=7,0,3,155,1,0,11,6,206,1401;GTC=10,0,8,537,4,0,40,15,714,4372;DP=8;GL=DIP2A;CP=0.0;CG=1.2;AA=.;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=NM_015151.3:intron,NM_015151.3:intron,NM_015151.3:intron,NM_001146116.1:intron,NM_001146116.1:intron,NM_001146116.1:intron;HGVS_CDNA_VAR=NM_015151.3:c.3499-32del1,NM_015151.3:c.3499-32_3499-31del2,NM_015151.3:c.3499-33_3499-32insT,NM_001146116.1:c.3487-32del1,NM_001146116.1:c.3487-32_3487-31del2,NM_001146116.1:c.3487-33_3487-32insT;HGVS_PROTEIN_VAR=.,.,.,.,.,.;CDS_SIZES=NM_015151.3:4716,NM_015151.3:4716,NM_015151.3:4716,NM_001146116.1:4704,NM_001146116.1:4704,NM_001146116.1:4704;GS=.,.,.,.,.,.;PH=.,.,.,.,.,.;EA_AGE=.;AA_AGE=.\n";
+        Properties properties = new Properties();
+        properties.put("EA.AC", "EA_AC");
+        properties.put("EA.GTC", "EA_GTC");
+        properties.put("AA.AC", "AA_AC");
+        properties.put("AA.GTC", "AA_GTC");
+        properties.put("ALL.AC", "TAC");
+        properties.put("ALL.GTC", "ALL_GTC");
+        properties.put("GROUPS_ORDER", "EA,AA,ALL");
+        VariantFactory evsFactory = new VariantVcfEVSFactory(properties);
+
+        List<Variant> res = evsFactory.create(source, line);
+
+        // testing multiallelic AC 
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 172);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 3174);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 13);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 3174);
+        assertEquals(res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 221);
+        assertEquals(res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 3174);
+
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getAltAlleleCount(), 565);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getRefAlleleCount(), 10035);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getAltAlleleCount(), 48);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getRefAlleleCount(), 10035);
+        assertEquals(res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getAltAlleleCount(), 752);
+        assertEquals(res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getRefAlleleCount(), 10035);
+
+
+        // testing multiallelic GTS=A1A1,A1A2,A1A3,A1R,A2A2,A2A3,A2R,A3A3,A3R,RR;EA_GTC=1,2,3,4,5,6,7,8,9,10
+        // first allele variant
+        List<Genotype> genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "", "T"));
+        genotypes.add(new Genotype("1/2", "", "T"));
+        genotypes.add(new Genotype("1/3", "", "T"));
+        genotypes.add(new Genotype("0/1", "", "T"));
+        genotypes.add(new Genotype("2/2", "", "T"));
+        genotypes.add(new Genotype("2/3", "", "T"));
+        genotypes.add(new Genotype("0/2", "", "T"));
+        genotypes.add(new Genotype("3/3", "", "T"));
+        genotypes.add(new Genotype("0/3", "", "T"));
+        genotypes.add(new Genotype("0/0", "", "T"));
+        
+        List<Integer> counts = new ArrayList<>(Arrays.asList(1,2,3,4,5,6,7,8,9,10));
+        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+//        genotypes.add(new Genotype("2/0", "CTT", "C"));
+//        genotypes.add(new Genotype("0/0", "CTT", "CT"));
+
+        // second allele variant
+        genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "TT", ""));
+        genotypes.add(new Genotype("1/2", "TT", ""));
+        genotypes.add(new Genotype("1/3", "TT", ""));
+        genotypes.add(new Genotype("0/1", "TT", ""));
+        genotypes.add(new Genotype("2/2", "TT", ""));
+        genotypes.add(new Genotype("2/3", "TT", ""));
+        genotypes.add(new Genotype("0/2", "TT", ""));
+        genotypes.add(new Genotype("3/3", "TT", ""));
+        genotypes.add(new Genotype("0/3", "TT", ""));
+        genotypes.add(new Genotype("0/0", "TT", ""));
+        counts = new ArrayList<>(Arrays.asList(5, 2, 6, 7, 1, 3, 4, 8, 9, 10)); // taking A2 as if it were the first allele A1, and moving A1 to A2
+        genotypesCount = res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+        
+        // third allele variant
+        genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "T", ""));
+        genotypes.add(new Genotype("1/2", "T", ""));
+        genotypes.add(new Genotype("1/3", "T", ""));
+        genotypes.add(new Genotype("0/1", "T", ""));
+        genotypes.add(new Genotype("2/2", "T", ""));
+        genotypes.add(new Genotype("2/3", "T", ""));
+        genotypes.add(new Genotype("0/2", "T", ""));
+        genotypes.add(new Genotype("3/3", "T", ""));
+        genotypes.add(new Genotype("0/3", "T", ""));
+        genotypes.add(new Genotype("0/0", "T", ""));
+        counts = new ArrayList<>(Arrays.asList(8, 3, 6, 9, 1, 2, 4, 5, 7, 10));// taking A3 as if it were the first allele A1, and moving A1 to A2, and A2 to A3
+        genotypesCount = res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+        
+        
+        // --------------------- testing multiallelic SNV
+        line = "9\t17579190\trs4961573\tC\tG,A\t.\tPASS\tDBSNP=dbSNP_111;EA_AC=8156,0,0;AA_AC=4110,10,0;TAC=12266,10,0;MAF=0.0,0.2427,0.0815;GTS=GG,GA,GC,AA,AC,CC;EA_GTC=1,2,3,4,5,6;AA_GTC=2050,10,0,0,0,0;GTC=6128,10,0,0,0,0;DP=6;GL=SH3GL2;CP=0.0;CG=-1.8;AA=G;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=NM_003026.2:utr-5,NM_003026.2:utr-5;HGVS_CDNA_VAR=NM_003026.2:c.-51C>A,NM_003026.2:c.-51C>G;HGVS_PROTEIN_VAR=.,.;CDS_SIZES=NM_003026.2:1059,NM_003026.2:1059;GS=.,.;PH=.,.;EA_AGE=.;AA_AGE=.";
+
+        res = evsFactory.create(source, line);
+
+        // testing AC
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 4110);
+        assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 0);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 10);
+        assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 0);
+        
+        genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "C", "G"));
+        genotypes.add(new Genotype("1/2", "C", "G"));
+        genotypes.add(new Genotype("0/1", "C", "G"));
+        genotypes.add(new Genotype("2/2", "C", "G"));
+        genotypes.add(new Genotype("0/2", "C", "G"));
+        genotypes.add(new Genotype("0/0", "C", "G"));
+        
+        counts = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6));
+        genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+        
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+
+
+        genotypes = new LinkedList<>();
+        genotypes.add(new Genotype("1/1", "C", "A"));
+        genotypes.add(new Genotype("1/2", "C", "A"));
+        genotypes.add(new Genotype("0/1", "C", "A"));
+        genotypes.add(new Genotype("2/2", "C", "A"));
+        genotypes.add(new Genotype("0/2", "C", "A"));
+        genotypes.add(new Genotype("0/0", "C", "A"));
+        counts = new ArrayList<>(Arrays.asList(4, 2, 5, 1, 3, 6));
+        genotypesCount = res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+
+        for (int i = 0; i < genotypes.size(); i++) {
+            assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
+        }
+
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfEVSFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfEVSFactoryTest.java
@@ -1,29 +1,55 @@
-package org.opencb.biodata.models.variant;
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.io.mappers;
 
 import org.junit.Test;
 import org.opencb.biodata.models.feature.Genotype;
+import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.commons.test.GenericTest;
 
-import java.util.*;
+import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.commons.models.data.VariantSourceEntry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
 /**
- * @author Alejandro Aleman Ramos &lt;aaleman@cipf.es&gt;
- * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
- * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ * {@link VariantVcfEVSFactory}
+ * input: an EVS aggregated VCF
+ * output: a List of Variants
  */
 public class VariantVcfEVSFactoryTest extends GenericTest {
 
     private VariantSource source = new VariantSource("EVS", "EVS", "EVS", "EVS");
-    private VariantFactory factory = new VariantVcfEVSFactory();
+
+    private VariantVcfFactory factory = new VariantVcfEVSFactory();
 
     @Test
     public void testCreate_AA_AC_TT_GT() throws Exception { // AA,AC,TT,GT,...
 
-        String line="1\t69428\trs140739101\tT\tG\t.\tPASS\tMAF=4.5707,0.3663,3.0647;GTS=GG,GT,TT;GTC=93,141,5101";
+        String line = "1\t69428\trs140739101\tT\tG\t.\tPASS\tMAF=4.5707,0.3663,3.0647;GTS=GG,GT,TT;GTC=93,141,5101";
 
         List<Variant> res = factory.create(source, line);
 
@@ -34,16 +60,16 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
 
         Map<Genotype, Integer> genotypes = new HashMap<>();
 
-        genotypes.put(new Genotype("0/0","T","G"), 5101);
-        genotypes.put(new Genotype("0/1","T","G"), 141);
-        genotypes.put(new Genotype("1/1","T","G"), 93);
+        genotypes.put(new Genotype("0/0", "T", "G"), 5101);
+        genotypes.put(new Genotype("0/1", "T", "G"), 141);
+        genotypes.put(new Genotype("1/1", "T", "G"), 93);
 
         assertEquals(avf.getStats().getGenotypesCount(), genotypes);
 
     }
 
     @Test
-    public void testCreate_A_C_T_G(){ // A,C,T,G
+    public void testCreate_A_C_T_G() { // A,C,T,G
 
         String line = "Y\t25375759\trs373156833\tT\tA\t.\tPASS\tMAF=0.0,0.1751,0.0409;GTS=A,T;GTC=1,2442";
         List<Variant> res = factory.create(source, line);
@@ -63,8 +89,8 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
     }
 
     @Test
-    public void testCreate_R_RR_A1R_A1A1(){ // R, RR, A1R, A1A1
-        String line  ="X\t100117423\t.\tAG\tA\t.\tPASS\tMAF=0.0308,0.0269,0.0294;GTS=A1A1,A1R,RR,R;GTC=1,1,3947,2306;";
+    public void testCreate_R_RR_A1R_A1A1() { // R, RR, A1R, A1A1
+        String line = "X\t100117423\t.\tAG\tA\t.\tPASS\tMAF=0.0308,0.0269,0.0294;GTS=A1A1,A1R,RR,R;GTC=1,1,3947,2306;";
 
         List<Variant> res = factory.create(source, line);
 
@@ -89,7 +115,7 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
     }
 
     @Test
-    public void testCreate_R_RR_A1A1_A1R_A1(){ // A1,A2,A3
+    public void testCreate_R_RR_A1A1_A1R_A1() { // A1,A2,A3
         String line = "X\t106362078\trs3216052\tCT\tC\t.\tPASS\tMAF=18.1215,25.2889,38.7555;GTS=A1A1,A1R,A1,RR,R;GTC=960,1298,737,1691,1570";
 
 
@@ -115,7 +141,7 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
     }
 
     @Test
-    public void testCreate_A1A1_A1A2_A2R_A2_RR_R(){// A1A2,A1A3...
+    public void testCreate_A1A1_A1A2_A2R_A2_RR_R() {// A1A2,A1A3...
 
         String line = "X\t14039552\t.\tCA\tCAA,C\t.\tPASS\tMAF=5.3453,4.2467,4.9459;GTS=A1A1,A1A2,A1R,A1,A2A2,A2R,A2,RR,R;GTC=0,0,134,162,4,92,107,3707,2027;";
 
@@ -180,10 +206,10 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         properties.put("ALL.AC", "TAC");
         properties.put("ALL.GTC", "ALL_GTC");
         properties.put("GROUPS_ORDER", "EA,AA,ALL");
-        VariantFactory evsFactory = new VariantVcfEVSFactory(properties);
-        
+        VariantVcfFactory evsFactory = new VariantVcfEVSFactory(properties);
+
         List<Variant> res = evsFactory.create(source, line);
-        
+
         // Allele count
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getAltAlleleCount(), 1);
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getRefAlleleCount(), 3849);
@@ -194,24 +220,25 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getMaf(), 0.026 / 100, 0.000001);
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getMaf(), 0.0943 / 100, 0.000001);
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("ALL").getMaf(), 0.0502 / 100, 0.000001);
-        
+
         // GTC
         List<Genotype> genotypes = new LinkedList<>();
         genotypes.add(new Genotype("1/1", "G", ""));
         genotypes.add(new Genotype("0/1", "G", ""));
         genotypes.add(new Genotype("0/0", "G", ""));
         List<Integer> counts = new ArrayList<>(Arrays.asList(0, 1, 1924));
-        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA")
+                                                   .getGenotypesCount();
         for (int i = 0; i < genotypes.size(); i++) {
             assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
         }
-        
-        
+
+
         // -------------- SNV, (GTS are expressed in another way)
         line = "21\t10862547\trs373689868\tG\tA\t.\tPASS\tDBSNP=dbSNP_138;EA_AC=0,3182;AA_AC=6,1378;TAC=6,4560;MAF=0.0,0.4335,0.1314;GTS=AA,AG,GG;EA_GTC=0,0,1591;AA_GTC=0,6,686;GTC=0,6,2277;DP=93;GL=.;CP=0.0;CG=-1.5;AA=G;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=intergenic;HGVS_CDNA_VAR=.;HGVS_PROTEIN_VAR=.;CDS_SIZES=.;GS=.;PH=.;EA_AGE=.;AA_AGE=.";
 
         res = evsFactory.create(source, line);
-        
+
         genotypes = new LinkedList<>();
         genotypes.add(new Genotype("1/1", "G", "A"));
         genotypes.add(new Genotype("0/1", "G", "A"));
@@ -237,7 +264,7 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         properties.put("ALL.AC", "TAC");
         properties.put("ALL.GTC", "ALL_GTC");
         properties.put("GROUPS_ORDER", "EA,AA,ALL");
-        VariantFactory evsFactory = new VariantVcfEVSFactory(properties);
+        VariantVcfFactory evsFactory = new VariantVcfEVSFactory(properties);
 
         List<Variant> res = evsFactory.create(source, line);
 
@@ -270,9 +297,10 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         genotypes.add(new Genotype("3/3", "", "T"));
         genotypes.add(new Genotype("0/3", "", "T"));
         genotypes.add(new Genotype("0/0", "", "T"));
-        
-        List<Integer> counts = new ArrayList<>(Arrays.asList(1,2,3,4,5,6,7,8,9,10));
-        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
+
+        List<Integer> counts = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        Map<Genotype, Integer> genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA")
+                                                   .getGenotypesCount();
 
         for (int i = 0; i < genotypes.size(); i++) {
             assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
@@ -292,13 +320,14 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         genotypes.add(new Genotype("3/3", "TT", ""));
         genotypes.add(new Genotype("0/3", "TT", ""));
         genotypes.add(new Genotype("0/0", "TT", ""));
-        counts = new ArrayList<>(Arrays.asList(5, 2, 6, 7, 1, 3, 4, 8, 9, 10)); // taking A2 as if it were the first allele A1, and moving A1 to A2
+        counts = new ArrayList<>(Arrays.asList(5, 2, 6, 7, 1, 3, 4, 8, 9,
+                                               10)); // taking A2 as if it were the first allele A1, and moving A1 to A2
         genotypesCount = res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
 
         for (int i = 0; i < genotypes.size(); i++) {
             assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
         }
-        
+
         // third allele variant
         genotypes = new LinkedList<>();
         genotypes.add(new Genotype("1/1", "T", ""));
@@ -311,14 +340,15 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         genotypes.add(new Genotype("3/3", "T", ""));
         genotypes.add(new Genotype("0/3", "T", ""));
         genotypes.add(new Genotype("0/0", "T", ""));
-        counts = new ArrayList<>(Arrays.asList(8, 3, 6, 9, 1, 2, 4, 5, 7, 10));// taking A3 as if it were the first allele A1, and moving A1 to A2, and A2 to A3
+        counts = new ArrayList<>(Arrays.asList(8, 3, 6, 9, 1, 2, 4, 5, 7,
+                                               10));// taking A3 as if it were the first allele A1, and moving A1 to A2, and A2 to A3
         genotypesCount = res.get(2).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
 
         for (int i = 0; i < genotypes.size(); i++) {
             assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
         }
-        
-        
+
+
         // --------------------- testing multiallelic SNV
         line = "9\t17579190\trs4961573\tC\tG,A\t.\tPASS\tDBSNP=dbSNP_111;EA_AC=8156,0,0;AA_AC=4110,10,0;TAC=12266,10,0;MAF=0.0,0.2427,0.0815;GTS=GG,GA,GC,AA,AC,CC;EA_GTC=1,2,3,4,5,6;AA_GTC=2050,10,0,0,0,0;GTC=6128,10,0,0,0,0;DP=6;GL=SH3GL2;CP=0.0;CG=-1.8;AA=G;CA=.;EXOME_CHIP=no;GWAS_PUBMED=.;FG=NM_003026.2:utr-5,NM_003026.2:utr-5;HGVS_CDNA_VAR=NM_003026.2:c.-51C>A,NM_003026.2:c.-51C>G;HGVS_PROTEIN_VAR=.,.;CDS_SIZES=NM_003026.2:1059,NM_003026.2:1059;GS=.,.;PH=.,.;EA_AGE=.;AA_AGE=.";
 
@@ -329,7 +359,7 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         assertEquals(res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 0);
         assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getAltAlleleCount(), 10);
         assertEquals(res.get(1).getSourceEntry("EVS", "EVS").getCohortStats("AA").getRefAlleleCount(), 0);
-        
+
         genotypes = new LinkedList<>();
         genotypes.add(new Genotype("1/1", "C", "G"));
         genotypes.add(new Genotype("1/2", "C", "G"));
@@ -337,10 +367,10 @@ public class VariantVcfEVSFactoryTest extends GenericTest {
         genotypes.add(new Genotype("2/2", "C", "G"));
         genotypes.add(new Genotype("0/2", "C", "G"));
         genotypes.add(new Genotype("0/0", "C", "G"));
-        
+
         counts = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6));
         genotypesCount = res.get(0).getSourceEntry("EVS", "EVS").getCohortStats("EA").getGenotypesCount();
-        
+
         for (int i = 0; i < genotypes.size(); i++) {
             assertEquals(genotypesCount.get(genotypes.get(i)), counts.get(i));
         }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfExacFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfExacFactoryTest.java
@@ -1,0 +1,296 @@
+package org.opencb.biodata.models.variant;
+
+import org.junit.Test;
+import org.opencb.biodata.models.feature.Genotype;
+import org.opencb.biodata.models.variant.stats.VariantStats;
+import org.opencb.commons.test.GenericTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by jmmut on 2015-03-25.
+ *
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class VariantVcfExacFactoryTest extends GenericTest {
+
+    private VariantSource source = new VariantSource("Exac", "Exac", "Exac", "Exac");
+    private VariantFactory factory = new VariantVcfExacFactory();
+
+    @Test
+    public void basicLine() {
+        String line = "1\t13525\t.\tG\tT\t828.34\tVQSRTrancheSNP99.60to99.80\tAC=27;AC_AFR=0;AC_AMR=0;AC_Adj=22;AC_EAS=0;"
+                + "AC_FIN=0;AC_Het=22;AC_Hom=0;AC_NFE=1;AC_OTH=0;AC_SAS=21;AF=6.558e-04;AN=41168;AN_AFR=422;AN_AMR=120;AN_Adj=10890;"
+                + "AN_EAS=160;AN_FIN=8;AN_NFE=2772;AN_OTH=116;AN_SAS=7292;BaseQRankSum=-2.157e+00;ClippingRankSum=0.365;DP=155897;"
+                + "FS=9.009;GQ_MEAN=15.16;GQ_STDDEV=18.34;Het_AFR=0;Het_AMR=0;Het_EAS=0;Het_FIN=0;Het_NFE=1;Het_OTH=0;Het_SAS=21;"
+                + "Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0;InbreedingCoeff=-0.0798;MQ=31.32;MQ0=0;"
+                + "MQRankSum=-7.020e-01;NCC=62633;QD=0.84;ReadPosRankSum=-2.070e-01;VQSLOD=-3.495e+00;culprit=MQ;DP_HIST=13297|"
+                + "1771|705|1240|2938|369|143|60|23|17|12|5|2|2|0|0|0|0|0|0,0|0|1|2|5|1|8|1|3|2|2|2|0|0|0|0|0|0|0|0;GQ_HIST=325|"
+                + "14020|111|71|2653|324|189|33|11|13|3|9|2450|315|24|26|0|2|0|5,0|2|1|2|2|1|1|0|1|3|0|0|2|1|2|2|0|2|0|5;CSQ=T|"
+                + "ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|"
+                + "773||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.773G>T|||||||||||||||||"
+                + "||,T|ENSG00000223972|ENST00000450305|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|"
+                + "487||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||6/6|||ENST00000450305.2:n.487G>T||||||"
+                + "|||||||||||||,T|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript"
+                + "_variant|766||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n."
+                + "766G>T|||||||||||||||||||,T|ENSG00000223972|ENST00000518655|Transcript|non_coding_transcript_exon_variant&"
+                + "non_coding_transcript_variant|604||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||"
+                + "ENST00000518655.2:n.604G>T|||||||||||||||||||,T||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||"
+                + "1||||||regulatory_region|||||||||||||||||||||||||||||||";
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 1);
+
+        Variant v = res.get(0);
+        VariantSourceEntry sourceEntry = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("0/0", "G", "T"), (10890 - 22 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/1", "G", "T"), 22);
+        genotypes.put(new Genotype("1/1", "G", "T"), 0);
+
+        VariantStats stats = sourceEntry.getStats();
+        assertEquals(genotypes, stats.getGenotypesCount());
+        assertEquals(22, stats.getAltAlleleCount());
+        assertEquals(10890 - 22, stats.getRefAlleleCount());
+        assertEquals(22.0 / 10890, stats.getMaf(), 0.00001);
+    }
+
+    @Test
+    public void multiallelicLine() {
+        String line = "1\t69552\trs55874132\tG\tT,A,C\t6289.25\tVQSRTrancheSNP99.60to99.80\tAC=3,3,5;AC_AFR=0,0,0;AC_AMR=3,0,0;"
+                + "AC_Adj=3,3,0;AC_EAS=0,0,0;AC_FIN=0,0,0;AC_Het=1,1,0,0,0,0;AC_Hom=1,1,0;AC_NFE=0,0,0;AC_OTH=0,0,0;AC_SAS=0,3,0;"
+                + "AF=3.308e-05,3.308e-05,5.514e-05;AN=90684;AN_AFR=7828;AN_AMR=6546;AN_Adj=79012;AN_EAS=8394;AN_FIN=3354;"
+                + "AN_NFE=39846;AN_OTH=606;AN_SAS=12438;BaseQRankSum=0.736;ClippingRankSum=0.198;DB;DP=1383162;FS=1.848;"
+                + "GQ_MEAN=57.16;GQ_STDDEV=20.29;Het_AFR=0,0,0,0,0,0;Het_AMR=1,0,0,0,0,0;Het_EAS=0,0,0,0,0,0;Het_FIN=0,0,0,0,0,0;"
+                + "Het_NFE=0,0,0,0,0,0;Het_OTH=0,0,0,0,0,0;Het_SAS=0,1,0,0,0,0;Hom_AFR=0,0,0;Hom_AMR=1,0,0;Hom_EAS=0,0,0;"
+                + "Hom_FIN=0,0,0;Hom_NFE=0,0,0;Hom_OTH=0,0,0;Hom_SAS=0,1,0;InbreedingCoeff=0.0345;MQ=30.21;MQ0=0;MQRankSum=-1.231e+00;"
+                + "NCC=25596;QD=9.65;ReadPosRankSum=0.920;VQSLOD=-2.686e+00;culprit=MQ;DP_HIST=4764|1048|70|7|7472|10605|4702|4511|"
+                + "4937|3377|1835|886|500|250|128|63|35|22|13|117,0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|1,0|0|0|0|0|0|0|0|0|0|0|1|0"
+                + "|0|0|0|0|0|0|1,3|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=533|4275|91|84|874|13|15|4|2|0|1|0|28889|7105|1334|"
+                + "1168|438|98|75|343,0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|2,0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|2,1|2|0|0|0|0|0|0|"
+                + "0|0|0|0|0|0|0|0|0|0|0|0;CSQ=A|ENSG00000186092|ENST00000335137|Transcript|synonymous_variant|462|462|154|A|gcG/gcA|"
+                + "rs55874132|2||1|OR4F5|HGNC|14825|protein_coding|YES|CCDS30547.1|ENSP00000334393|OR4F5_HUMAN||UPI0000041BC1|||1/1||"
+                + "Pfam_domain:PF00001&Pfam_domain:PF10320&PROSITE_profiles:PS50262&Superfamily_domains:SSF81321|ENST00000335137.3:c."
+                + "462G>A|ENST00000335137.3:c.462G>A(p.%3D)||||||||||||||||||,T|ENSG00000186092|ENST00000335137|Transcript|synonymous"
+                + "_variant|462|462|154|A|gcG/gcT|rs55874132|1||1|OR4F5|HGNC|14825|protein_coding|YES|CCDS30547.1|ENSP00000334393|"
+                + "OR4F5_HUMAN||UPI0000041BC1|||1/1||Pfam_domain:PF00001&Pfam_domain:PF10320&PROSITE_profiles:PS50262&Superfamily_"
+                + "domains:SSF81321|ENST00000335137.3:c.462G>T|ENST00000335137.3:c.462G>T(p.%3D)||||||||||||||||||,C|ENSG00000186092|"
+                + "ENST00000335137|Transcript|synonymous_variant|462|462|154|A|gcG/gcC|rs55874132|3||1|OR4F5|HGNC|14825|protein_coding|"
+                + "YES|CCDS30547.1|ENSP00000334393|OR4F5_HUMAN||UPI0000041BC1|||1/1||Pfam_domain:PF00001&Pfam_domain:PF10320&PROSITE_"
+                + "profiles:PS50262&Superfamily_domains:SSF81321|ENST00000335137.3:c.462G>C|ENST00000335137.3:c.462G>C(p.%3D)||||||||"
+                + "||||||||||,A||ENSR00000278218|RegulatoryFeature|regulatory_region_variant||||||rs55874132|2||||||regulatory_region|"
+                + "||||||||||||||||||||||||||||||,T||ENSR00000278218|RegulatoryFeature|regulatory_region_variant||||||rs55874132|1||||"
+                + "||regulatory_region|||||||||||||||||||||||||||||||,C||ENSR00000278218|RegulatoryFeature|regulatory_region_variant||"
+                + "||||rs55874132|3||||||regulatory_region|||||||||||||||||||||||||||||||";
+
+        List<Variant> res = factory.create(source, line);
+
+        assertTrue(res.size() == 3);
+
+        Variant v = res.get(0);
+        VariantSourceEntry sourceEntry = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        Map<Genotype, Integer> genotypes = new HashMap<>();
+
+        genotypes.put(new Genotype("0/0", "G", "T"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/1", "G", "T"), 1);
+        genotypes.put(new Genotype("1/1", "G", "T"), 1);
+        genotypes.put(new Genotype("0/2", "G", "T"), 1);
+        genotypes.put(new Genotype("1/2", "G", "T"), 0);
+        genotypes.put(new Genotype("2/2", "G", "T"), 1);
+        genotypes.put(new Genotype("0/3", "G", "T"), 0);
+        genotypes.put(new Genotype("1/3", "G", "T"), 0);
+        genotypes.put(new Genotype("2/3", "G", "T"), 0);
+        genotypes.put(new Genotype("3/3", "G", "T"), 0);
+
+        assertEquals(genotypes, sourceEntry.getStats().getGenotypesCount());
+        assertEquals(3, sourceEntry.getStats().getAltAlleleCount());
+        assertEquals(79012 - 1 - 2 - 1 - 2, sourceEntry.getStats().getRefAlleleCount());
+        assertEquals(0, sourceEntry.getStats().getMaf(), 0.00001);   // how can a multiallelic variant have an allele count of 0? the "Adjusted" just removed it
+
+        genotypes.clear();
+        genotypes.put(new Genotype("0/0", "G", "A"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/1", "G", "A"), 1);
+        genotypes.put(new Genotype("1/1", "G", "A"), 1);
+        genotypes.put(new Genotype("0/2", "G", "A"), 1);
+        genotypes.put(new Genotype("1/2", "G", "A"), 0);
+        genotypes.put(new Genotype("2/2", "G", "A"), 1);
+        genotypes.put(new Genotype("0/3", "G", "A"), 0);
+        genotypes.put(new Genotype("1/3", "G", "A"), 0);
+        genotypes.put(new Genotype("2/3", "G", "A"), 0);
+        genotypes.put(new Genotype("3/3", "G", "A"), 0);
+
+        sourceEntry = res.get(1).getSourceEntry(source.getFileId(), source.getStudyId());
+
+        assertEquals(genotypes, sourceEntry.getStats().getGenotypesCount());
+        assertEquals(3, sourceEntry.getStats().getAltAlleleCount());
+        assertEquals(79012 - 1 - 2 - 1 - 2, sourceEntry.getStats().getRefAlleleCount());
+
+        genotypes.clear();
+        genotypes.put(new Genotype("0/0", "G", "C"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/1", "G", "C"), 0);
+        genotypes.put(new Genotype("1/1", "G", "C"), 0);
+        genotypes.put(new Genotype("0/2", "G", "C"), 1);
+        genotypes.put(new Genotype("1/2", "G", "C"), 0);
+        genotypes.put(new Genotype("2/2", "G", "C"), 1);
+        genotypes.put(new Genotype("0/3", "G", "C"), 1);
+        genotypes.put(new Genotype("1/3", "G", "C"), 0);
+        genotypes.put(new Genotype("2/3", "G", "C"), 0);
+        genotypes.put(new Genotype("3/3", "G", "C"), 1);
+
+        sourceEntry = res.get(2).getSourceEntry(source.getFileId(), source.getStudyId());
+
+        assertEquals(genotypes, sourceEntry.getStats().getGenotypesCount());
+        assertEquals(0, sourceEntry.getStats().getAltAlleleCount());
+        assertEquals(79012 - 1 - 2 - 1 - 2, sourceEntry.getStats().getRefAlleleCount());
+    }
+
+    @Test
+    public void multiallelicPopulationGenotypes() {
+        String line = "1\t13528\t.\tC\tG,T\t1771.54\tVQSRTrancheSNP99.60to99.80\tAC=21,11;AC_AFR=12,0;AC_AMR=1,0;AC_Adj=13,9;"
+                + "AC_EAS=0,0;AC_FIN=0,0;AC_Het=13,9,0;AC_Hom=0,0;AC_NFE=0,2;AC_OTH=0,0;AC_SAS=0,7;AF=6.036e-04,3.162e-04;"
+                + "AN=34792;AN_AFR=390;AN_AMR=116;AN_Adj=10426;AN_EAS=150;AN_FIN=8;AN_NFE=2614;AN_OTH=116;AN_SAS=7032;"
+                + "BaseQRankSum=1.23;ClippingRankSum=0.056;DP=144988;FS=0.000;GQ_MEAN=14.54;GQ_STDDEV=16.53;Het_AFR=12,0,0;"
+                + "Het_AMR=1,0,0;Het_EAS=0,0,0;Het_FIN=0,0,0;Het_NFE=0,2,0;Het_OTH=0,0,0;Het_SAS=0,7,0;Hom_AFR=0,0;Hom_AMR=0,0;"
+                + "Hom_EAS=0,0;Hom_FIN=0,0;Hom_NFE=0,0;Hom_OTH=0,0;Hom_SAS=0,0;InbreedingCoeff=0.0557;MQ=31.08;MQ0=0;"
+                + "MQRankSum=-5.410e-01;NCC=67387;QD=1.91;ReadPosRankSum=0.206;VQSLOD=-2.705e+00;culprit=MQ;DP_HIST=10573|1503|"
+                + "705|1265|2477|613|167|52|18|11|8|3|0|0|1|0|0|0|0|0,2|6|2|1|4|0|3|1|0|0|2|0|0|0|0|0|0|0|0|0,1|0|0|0|1|1|3|0|"
+                + "1|1|1|0|0|0|1|0|0|0|0|0;GQ_HIST=342|11195|83|56|3154|517|367|60|12|4|5|7|1373|180|15|16|1|0|1|8,0|0|1|0|1|0|"
+                + "3|1|0|1|2|0|1|2|0|1|1|0|1|6,0|1|0|0|1|1|0|0|1|0|0|1|1|1|1|0|0|0|0|2;CSQ=T|ENSG00000223972|ENST00000456328|"
+                + "Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|776||||||2||1|DDX11L1|HGNC|"
+                + "37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.776C>T|||||||||||||||||||,G|ENSG00000223972|"
+                + "ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|776||||||1||1|"
+                + "DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.776C>G|||||||||||||||||||,T|"
+                + "ENSG00000223972|ENST00000450305|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|"
+                + "490||||||2||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||6/6|||ENST00000450305.2:n.490C>T|"
+                + "||||||||||||||||||,G|ENSG00000223972|ENST00000450305|Transcript|non_coding_transcript_exon_variant&non_coding"
+                + "_transcript_variant|490||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||6/6|||"
+                + "ENST00000450305.2:n.490C>G|||||||||||||||||||,T|ENSG00000223972|ENST00000515242|Transcript|non_coding_"
+                + "transcript_exon_variant&non_coding_transcript_variant|769||||||2||1|DDX11L1|HGNC|37102|transcribed_unprocessed"
+                + "_pseudogene|||||||||3/3|||ENST00000515242.2:n.769C>T|||||||||||||||||||,G|ENSG00000223972|ENST00000515242|"
+                + "Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|769||||||1||1|DDX11L1|HGNC|37102|"
+                + "transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.769C>G|||||||||||||||||||,T|ENSG00000223972|"
+                + "ENST00000518655|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|607||||||2||1|DDX11L1|"
+                + "HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.607C>T|||||||||||||||||||,G|"
+                + "ENSG00000223972|ENST00000518655|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|"
+                + "607||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.607C>G|"
+                + "||||||||||||||||||,T||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||2||||||regulatory_region|"
+                + "||||||||||||||||||||||||||||||,G||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||"
+                + "regulatory_region|||||||||||||||||||||||||||||||";
+
+        Properties properties = new Properties();
+        properties.put("AFR.AC",   "AC_AFR");
+        properties.put("AFR.AN",   "AN_AFR");
+        properties.put("AFR.HET", "Het_AFR");
+        properties.put("AFR.HOM", "Hom_AFR");
+        properties.put("AMR.AC",   "AC_AMR");
+        properties.put("AMR.AN",   "AN_AMR");
+        properties.put("AMR.HET", "Het_AMR");
+        properties.put("AMR.HOM", "Hom_AMR");
+        properties.put("EAS.AC",   "AC_EAS");
+        properties.put("EAS.AN",   "AN_EAS");
+        properties.put("EAS.HET", "Het_EAS");
+        properties.put("EAS.HOM", "Hom_EAS");
+        properties.put("FIN.AC",   "AC_FIN");
+        properties.put("FIN.AN",   "AN_FIN");
+        properties.put("FIN.HET", "Het_FIN");
+        properties.put("FIN.HOM", "Hom_FIN");
+        properties.put("NFE.AC",   "AC_NFE");
+        properties.put("NFE.AN",   "AN_NFE");
+        properties.put("NFE.HET", "Het_NFE");
+        properties.put("NFE.HOM", "Hom_NFE");
+        properties.put("OTH.AC",   "AC_OTH");
+        properties.put("OTH.AN",   "AN_OTH");
+        properties.put("OTH.HET", "Het_OTH");
+        properties.put("OTH.HOM", "Hom_OTH");
+        properties.put("SAS.AC",   "AC_SAS");
+        properties.put("SAS.AN",   "AN_SAS");
+        properties.put("SAS.HET", "Het_SAS");
+        properties.put("SAS.HOM", "Hom_SAS");
+        properties.put("ALL.AC",  "AC_Adj");
+        properties.put("ALL.AN",  "AN_Adj");
+        properties.put("ALL.HET", "AC_Het");
+        properties.put("ALL.HOM", "AC_Hom");
+        VariantFactory exacFactory = new VariantVcfExacFactory(properties);
+        List<Variant> res = exacFactory.create(source, line);
+
+        assertTrue(res.size() == 2);
+
+        Variant v = res.get(0);
+        VariantSourceEntry sourceEntry = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        // Allele and genotype counts
+        assertEquals(12, sourceEntry.getCohortStats("AFR").getAltAlleleCount());
+        Genotype genotype = new Genotype("0/1", v.getReference(), v.getAlternate());
+        assertEquals(12, (int) sourceEntry.getCohortStats("AFR").getGenotypesCount().get(genotype));
+        genotype = new Genotype("0/2", v.getReference(), v.getAlternate());
+        assertEquals(7, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
+        genotype = new Genotype("1/1", v.getReference(), v.getAlternate());
+        assertEquals(0, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
+        genotype = new Genotype("0/1", v.getReference(), v.getAlternate());
+        assertEquals(0, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
+        assertEquals(7025, sourceEntry.getCohortStats("SAS").getRefAlleleCount());
+        assertEquals(0, sourceEntry.getCohortStats("SAS").getAltAlleleCount());
+        
+        // Minor allele frequencies
+        assertEquals(9 / 10426.0, sourceEntry.getCohortStats("ALL").getMaf(), 0.00001);
+        assertEquals(0, sourceEntry.getCohortStats("SAS").getMaf(), 0.001);
+        assertEquals(0, sourceEntry.getCohortStats("AFR").getMaf(), 0.00001);
+        assertEquals(0, sourceEntry.getCohortStats("AMR").getMaf(), 0.00001);
+
+        System.out.println("genotypes for C -> G in SAS: " + sourceEntry.getCohortStats("SAS").getGenotypesCount());
+
+        v = res.get(1);
+        sourceEntry = v.getSourceEntry(source.getFileId(), source.getStudyId());
+
+        assertEquals(2, sourceEntry.getCohortStats("NFE").getAltAlleleCount());
+        genotype = new Genotype("0/2", v.getReference(), v.getAlternate());
+        assertEquals(12, (int) sourceEntry.getCohortStats("AFR").getGenotypesCount().get(genotype));
+        genotype = new Genotype("0/1", v.getReference(), v.getAlternate());
+        assertEquals(7, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
+        assertEquals(7025, sourceEntry.getCohortStats("SAS").getRefAlleleCount());
+        assertEquals(7, sourceEntry.getCohortStats("SAS").getAltAlleleCount());
+        genotype = new Genotype("0/0", v.getReference(), v.getAlternate());
+        assertEquals(7018 / 2, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
+        System.out.println("genotypes for C -> T in SAS: " + sourceEntry.getCohortStats("SAS").getGenotypesCount());
+    }
+
+    @Test
+    public void testGetHeterozygousGenotype() throws Exception {
+        VariantVcfExacFactory factory = new VariantVcfExacFactory();
+        for (int i = 0; i < 11; i++) {
+            Integer alleles[] = new Integer[2];
+            VariantVcfExacFactory.getHeterozygousGenotype(i, 4, alleles);
+            System.out.println("alleles[" + i + "] = " + alleles[0] + "/" + alleles[1]);
+        }
+
+        Integer alleles[] = new Integer[2];
+        VariantVcfExacFactory.getHeterozygousGenotype(3, 3, alleles);
+        assertEquals(alleles[0], new Integer(1));
+        assertEquals(alleles[1], new Integer(2));
+        VariantVcfExacFactory.getHeterozygousGenotype(4, 4, alleles);
+        assertEquals(alleles[0], new Integer(1));
+        assertEquals(alleles[1], new Integer(2));
+    }
+
+    @Test
+    public void testGetHomozygousGenotype() throws Exception {
+        VariantVcfExacFactory factory = new VariantVcfExacFactory();
+        for (int i = 0; i < 11; i++) {
+            Integer alleles[] = new Integer[2];
+            VariantVcfExacFactory.getHomozygousGenotype(i, alleles);
+            System.out.println("alleles[" + i + "] = " + alleles[0] + "/" + alleles[1]);
+        }
+
+        Integer alleles[] = new Integer[2];
+        VariantVcfExacFactory.getHomozygousGenotype(3, alleles);    // 0/0
+        assertEquals(alleles[0], alleles[1]);
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfExacFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfExacFactoryTest.java
@@ -1,26 +1,47 @@
-package org.opencb.biodata.models.variant;
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.io.mappers;
 
 import org.junit.Test;
 import org.opencb.biodata.models.feature.Genotype;
-import org.opencb.biodata.models.variant.stats.VariantStats;
+import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.commons.test.GenericTest;
+
+import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.commons.models.data.VariantSourceEntry;
+import uk.ac.ebi.eva.commons.models.data.VariantStats;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Created by jmmut on 2015-03-25.
- *
- * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ * {@link VariantVcfExacFactory}
+ * input: an Exac aggregated VCF
+ * output: a List of Variants
  */
 public class VariantVcfExacFactoryTest extends GenericTest {
 
     private VariantSource source = new VariantSource("Exac", "Exac", "Exac", "Exac");
-    private VariantFactory factory = new VariantVcfExacFactory();
+
+    private VariantVcfFactory factory = new VariantVcfExacFactory();
 
     @Test
     public void basicLine() {
@@ -51,7 +72,8 @@ public class VariantVcfExacFactoryTest extends GenericTest {
 
         Map<Genotype, Integer> genotypes = new HashMap<>();
 
-        genotypes.put(new Genotype("0/0", "G", "T"), (10890 - 22 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/0", "G", "T"),
+                      (10890 - 22 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
         genotypes.put(new Genotype("0/1", "G", "T"), 22);
         genotypes.put(new Genotype("1/1", "G", "T"), 0);
 
@@ -99,7 +121,8 @@ public class VariantVcfExacFactoryTest extends GenericTest {
 
         Map<Genotype, Integer> genotypes = new HashMap<>();
 
-        genotypes.put(new Genotype("0/0", "G", "T"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/0", "G", "T"),
+                      (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
         genotypes.put(new Genotype("0/1", "G", "T"), 1);
         genotypes.put(new Genotype("1/1", "G", "T"), 1);
         genotypes.put(new Genotype("0/2", "G", "T"), 1);
@@ -113,10 +136,12 @@ public class VariantVcfExacFactoryTest extends GenericTest {
         assertEquals(genotypes, sourceEntry.getStats().getGenotypesCount());
         assertEquals(3, sourceEntry.getStats().getAltAlleleCount());
         assertEquals(79012 - 1 - 2 - 1 - 2, sourceEntry.getStats().getRefAlleleCount());
-        assertEquals(0, sourceEntry.getStats().getMaf(), 0.00001);   // how can a multiallelic variant have an allele count of 0? the "Adjusted" just removed it
+        assertEquals(0, sourceEntry.getStats().getMaf(),
+                     0.00001);   // how can a multiallelic variant have an allele count of 0? the "Adjusted" just removed it
 
         genotypes.clear();
-        genotypes.put(new Genotype("0/0", "G", "A"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/0", "G", "A"),
+                      (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
         genotypes.put(new Genotype("0/1", "G", "A"), 1);
         genotypes.put(new Genotype("1/1", "G", "A"), 1);
         genotypes.put(new Genotype("0/2", "G", "A"), 1);
@@ -134,7 +159,8 @@ public class VariantVcfExacFactoryTest extends GenericTest {
         assertEquals(79012 - 1 - 2 - 1 - 2, sourceEntry.getStats().getRefAlleleCount());
 
         genotypes.clear();
-        genotypes.put(new Genotype("0/0", "G", "C"), (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
+        genotypes.put(new Genotype("0/0", "G", "C"),
+                      (79012 - 4 * 2) / 2);    // AN - alleles_in_gt_0/1: how many ref alleles there are in the genotype 0/0, as there are no 1/1
         genotypes.put(new Genotype("0/1", "G", "C"), 0);
         genotypes.put(new Genotype("1/1", "G", "C"), 0);
         genotypes.put(new Genotype("0/2", "G", "C"), 1);
@@ -186,39 +212,39 @@ public class VariantVcfExacFactoryTest extends GenericTest {
                 + "regulatory_region|||||||||||||||||||||||||||||||";
 
         Properties properties = new Properties();
-        properties.put("AFR.AC",   "AC_AFR");
-        properties.put("AFR.AN",   "AN_AFR");
+        properties.put("AFR.AC", "AC_AFR");
+        properties.put("AFR.AN", "AN_AFR");
         properties.put("AFR.HET", "Het_AFR");
         properties.put("AFR.HOM", "Hom_AFR");
-        properties.put("AMR.AC",   "AC_AMR");
-        properties.put("AMR.AN",   "AN_AMR");
+        properties.put("AMR.AC", "AC_AMR");
+        properties.put("AMR.AN", "AN_AMR");
         properties.put("AMR.HET", "Het_AMR");
         properties.put("AMR.HOM", "Hom_AMR");
-        properties.put("EAS.AC",   "AC_EAS");
-        properties.put("EAS.AN",   "AN_EAS");
+        properties.put("EAS.AC", "AC_EAS");
+        properties.put("EAS.AN", "AN_EAS");
         properties.put("EAS.HET", "Het_EAS");
         properties.put("EAS.HOM", "Hom_EAS");
-        properties.put("FIN.AC",   "AC_FIN");
-        properties.put("FIN.AN",   "AN_FIN");
+        properties.put("FIN.AC", "AC_FIN");
+        properties.put("FIN.AN", "AN_FIN");
         properties.put("FIN.HET", "Het_FIN");
         properties.put("FIN.HOM", "Hom_FIN");
-        properties.put("NFE.AC",   "AC_NFE");
-        properties.put("NFE.AN",   "AN_NFE");
+        properties.put("NFE.AC", "AC_NFE");
+        properties.put("NFE.AN", "AN_NFE");
         properties.put("NFE.HET", "Het_NFE");
         properties.put("NFE.HOM", "Hom_NFE");
-        properties.put("OTH.AC",   "AC_OTH");
-        properties.put("OTH.AN",   "AN_OTH");
+        properties.put("OTH.AC", "AC_OTH");
+        properties.put("OTH.AN", "AN_OTH");
         properties.put("OTH.HET", "Het_OTH");
         properties.put("OTH.HOM", "Hom_OTH");
-        properties.put("SAS.AC",   "AC_SAS");
-        properties.put("SAS.AN",   "AN_SAS");
+        properties.put("SAS.AC", "AC_SAS");
+        properties.put("SAS.AN", "AN_SAS");
         properties.put("SAS.HET", "Het_SAS");
         properties.put("SAS.HOM", "Hom_SAS");
-        properties.put("ALL.AC",  "AC_Adj");
-        properties.put("ALL.AN",  "AN_Adj");
+        properties.put("ALL.AC", "AC_Adj");
+        properties.put("ALL.AN", "AN_Adj");
         properties.put("ALL.HET", "AC_Het");
         properties.put("ALL.HOM", "AC_Hom");
-        VariantFactory exacFactory = new VariantVcfExacFactory(properties);
+        VariantVcfFactory exacFactory = new VariantVcfExacFactory(properties);
         List<Variant> res = exacFactory.create(source, line);
 
         assertTrue(res.size() == 2);
@@ -238,7 +264,7 @@ public class VariantVcfExacFactoryTest extends GenericTest {
         assertEquals(0, (int) sourceEntry.getCohortStats("SAS").getGenotypesCount().get(genotype));
         assertEquals(7025, sourceEntry.getCohortStats("SAS").getRefAlleleCount());
         assertEquals(0, sourceEntry.getCohortStats("SAS").getAltAlleleCount());
-        
+
         // Minor allele frequencies
         assertEquals(9 / 10426.0, sourceEntry.getCohortStats("ALL").getMaf(), 0.00001);
         assertEquals(0, sourceEntry.getCohortStats("SAS").getMaf(), 0.001);
@@ -264,7 +290,6 @@ public class VariantVcfExacFactoryTest extends GenericTest {
 
     @Test
     public void testGetHeterozygousGenotype() throws Exception {
-        VariantVcfExacFactory factory = new VariantVcfExacFactory();
         for (int i = 0; i < 11; i++) {
             Integer alleles[] = new Integer[2];
             VariantVcfExacFactory.getHeterozygousGenotype(i, 4, alleles);
@@ -282,7 +307,6 @@ public class VariantVcfExacFactoryTest extends GenericTest {
 
     @Test
     public void testGetHomozygousGenotype() throws Exception {
-        VariantVcfExacFactory factory = new VariantVcfExacFactory();
         for (int i = 0; i < 11; i++) {
             Integer alleles[] = new Integer[2];
             VariantVcfExacFactory.getHomozygousGenotype(i, alleles);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
@@ -1,22 +1,48 @@
-package org.opencb.biodata.models.variant;
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.io.mappers;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opencb.biodata.models.variant.VariantSource;
 
-import java.util.*;
+import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.commons.models.data.VariantSourceEntry;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertArrayEquals;
-
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
- * @author Alejandro Aleman Ramos &lt;aaleman@cipf.es&gt;
- * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ * {@link VariantVcfFactory}
+ * input: a genotyped VCF
+ * output: a List of Variants
  */
 public class VariantVcfFactoryTest {
 
     private VariantSource source = new VariantSource("filename.vcf", "fileId", "studyId", "studyName");
-    private VariantFactory factory = new VariantVcfFactory();
+
+    private VariantVcfFactory factory = new VariantVcfFactory();
 
     @Before
     public void setUp() throws Exception {
@@ -75,62 +101,62 @@ public class VariantVcfFactoryTest {
         expResult.add(new Variant("1", 1000, 1000 + "CGATT".length() - 1, "CGATT", "TAC"));
         List<Variant> result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tAT\tA\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tGATC\tG\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1003, "ATC", ""));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\t.\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1002, "", "ATC"));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tA\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1002, "", "TC"));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tAC\tACT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1002, 1002, "", "T"));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         // Printing those that are not currently managed
         line = "1\t1000\trs123\tAT\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tATC\tTC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tATC\tAC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tAC\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "", "T"));
         result = factory.create(source, line);
         assertEquals(expResult, result);
-        
+
         line = "1\t1000\trs123\tATC\tGC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1001, "AT", "G"));
@@ -157,9 +183,6 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariant_Samples() {
-        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005");
-        source.setSamples(sampleNames);
-
         String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0/1\t0/.\t./1\t1/1"; // 5 samples
 
         // Initialize expected variants
@@ -179,25 +202,24 @@ public class VariantVcfFactoryTest {
         Map<String, String> na005 = new HashMap<>();
         na005.put("GT", "1/1");
 
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na005);
 
         // Check proper conversion of samples
         List<Variant> result = factory.create(source, line);
         assertEquals(1, result.size());
 
         Variant getVar0 = result.get(0);
-        assertEquals(var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+        assertEquals(var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(),
+                     getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
     }
 
     @Test
     public void testCreateVariantFromVcfMultiallelicVariants_Samples() {
-        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
-        source.setSamples(sampleNames);
-        String line ="1\t123456\t.\tT\tC,G\t110\tPASS\t.\tGT:AD:DP:GQ:PL\t0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t1/2:7,6:13:99:162,0,180"; // 4 samples
+        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\t.\tGT:AD:DP:GQ:PL\t0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t1/2:7,6:13:99:162,0,180"; // 4 samples
 
         // Initialize expected variants
         Variant var0 = new Variant("1", 123456, 123456, "T", "C");
@@ -235,11 +257,11 @@ public class VariantVcfFactoryTest {
         na004_C.put("GQ", "99");
         na004_C.put("PL", "162,0,180");
 
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_C);
-        
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004_C);
+
         // Initialize expected samples in variant 2 (alt allele G)
         Map<String, String> na001_G = new HashMap<>();
         na001_G.put("GT", "0/2");
@@ -265,10 +287,10 @@ public class VariantVcfFactoryTest {
         na004_G.put("DP", "13");
         na004_G.put("GQ", "99");
         na004_G.put("PL", "162,0,180");
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_G);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_G);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_G);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004_G);
 
 
         // Check proper conversion of samples and alternate alleles
@@ -277,22 +299,22 @@ public class VariantVcfFactoryTest {
 
         Variant getVar0 = result.get(0);
         assertEquals(
-                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(),
                 getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
-        assertArrayEquals(new String[]{ "G" }, getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+        assertArrayEquals(new String[]{"G"},
+                          getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
 
         Variant getVar1 = result.get(1);
         assertEquals(
-                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(),
                 getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
-        assertArrayEquals(new String[]{ "C" }, getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+        assertArrayEquals(new String[]{"C"},
+                          getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
     }
 
     @Test
     public void testCreateVariantFromVcfCoLocatedVariants_Samples() {
-        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005", "NA006");
-        source.setSamples(sampleNames);
-        String line = "1\t10040\trs123\tT\tC,GC\t.\t.\t.\tGT:GL\t0/0:1,2,3,4,5,6,7,8,9,10\t0/1:1,2,3,4,5,6,7,8,9,10\t0/2:1,2,3,4,5,6,7,8,9,10\t1/1:1,2,3,4,5,6,7,8,9,10\t1/2:1,2,3,4,5,6,7,8,9,10\t2/2:1,2,3,4,5,6,7,8,9,10"; // 6 samples
+        String line = "1\t10040\trs123\tT\tC,GC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/1\t1/2\t2/2"; // 6 samples
 
         // Initialize expected variants
         Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
@@ -306,56 +328,44 @@ public class VariantVcfFactoryTest {
         // Initialize expected samples in variant 1 (alt allele C)
         Map<String, String> na001_C = new HashMap<>();
         na001_C.put("GT", "0/0");
-        na001_C.put("GL", "1,1,1");
         Map<String, String> na002_C = new HashMap<>();
         na002_C.put("GT", "0/1");
-        na002_C.put("GL", "1,2,3");
         Map<String, String> na003_C = new HashMap<>();
         na003_C.put("GT", "0/2");
-        na003_C.put("GL", "1,4,6");
         Map<String, String> na004_C = new HashMap<>();
         na004_C.put("GT", "1/1");
-        na004_C.put("GL", "1,2,3");
         Map<String, String> na005_C = new HashMap<>();
         na005_C.put("GT", "1/2");
-        na005_C.put("GL", "3,5,6");
         Map<String, String> na006_C = new HashMap<>();
         na006_C.put("GT", "2/2");
-        na006_C.put("GL", "1,4,6");
 
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005_C);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(5), na006_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na005_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na006_C);
 
         // TODO Initialize expected samples in variant 2 (alt allele GC)
         Map<String, String> na001_GC = new HashMap<>();
         na001_GC.put("GT", "0/0");
-        na001_GC.put("GL", "1,1,1");
         Map<String, String> na002_GC = new HashMap<>();
         na002_GC.put("GT", "0/2");
-        na002_GC.put("GL", "1,2,3");
         Map<String, String> na003_GC = new HashMap<>();
         na003_GC.put("GT", "0/1");
-        na003_GC.put("GL", "1,4,6");
         Map<String, String> na004_GC = new HashMap<>();
         na004_GC.put("GT", "2/2");
-        na004_GC.put("GL", "1,2,3");
         Map<String, String> na005_GC = new HashMap<>();
         na005_GC.put("GT", "2/1");
-        na005_GC.put("GL", "3,5,6");
         Map<String, String> na006_GC = new HashMap<>();
         na006_GC.put("GT", "1/1");
-        na006_GC.put("GL", "1,4,6");
-        
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_GC);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_GC);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_GC);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_GC);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005_GC);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(5), na006_GC);
+
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na005_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na006_GC);
 
         // Check proper conversion of samples
         List<Variant> result = factory.create(source, line);
@@ -363,28 +373,28 @@ public class VariantVcfFactoryTest {
 
         Variant getVar0 = result.get(0);
         assertEquals(
-                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(),
                 getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
-        assertArrayEquals(new String[]{ "GC" }, getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+        assertArrayEquals(new String[]{"GC"},
+                          getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
 
         Variant getVar1 = result.get(1);
         assertEquals(
-                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(),
                 getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
-        assertArrayEquals(new String[]{ "C" }, getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+        assertArrayEquals(new String[]{"C"},
+                          getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
     }
-    
+
     @Test
     public void testCreateVariantWithMissingGenotypes() {
-        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
-        source.setSamples(sampleNames);
         String line = "1\t1407616\t.\tC\tG\t43.74\tPASS\t.\tGT:AD:DP:GQ:PL\t./.:.:.:.:.\t1/1:0,2:2:6:71,6,0\t./.:.:.:.:.\t./.:.:.:.:.";
-    
+
         // Initialize expected variants
         Variant var0 = new Variant("1", 1407616, 1407616, "C", "G");
         VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
         var0.addSourceEntry(file0);
-        
+
         // Initialize expected samples
         Map<String, String> na001 = new HashMap<>();
         na001.put("GT", "./.");
@@ -410,56 +420,54 @@ public class VariantVcfFactoryTest {
         na004.put("DP", ".");
         na004.put("GQ", ".");
         na004.put("PL", ".");
-        
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
-        
-        
+
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004);
+
+
         // Check proper conversion of samples
         List<Variant> result = factory.create(source, line);
         assertEquals(1, result.size());
 
         Variant getVar0 = result.get(0);
         VariantSourceEntry getFile0 = getVar0.getSourceEntry(source.getFileId(), source.getStudyId());
-        
-        Map<String, String> na001Data = getFile0.getSampleData("NA001");
+
+        Map<String, String> na001Data = getFile0.getSampleData(0);
         assertEquals("./.", na001Data.get("GT"));
         assertEquals(".", na001Data.get("AD"));
         assertEquals(".", na001Data.get("DP"));
         assertEquals(".", na001Data.get("GQ"));
         assertEquals(".", na001Data.get("PL"));
-        
-        Map<String, String> na002Data = getFile0.getSampleData("NA002");
+
+        Map<String, String> na002Data = getFile0.getSampleData(1);
         assertEquals("1/1", na002Data.get("GT"));
         assertEquals("0,2", na002Data.get("AD"));
         assertEquals("2", na002Data.get("DP"));
         assertEquals("6", na002Data.get("GQ"));
         assertEquals("71,6,0", na002Data.get("PL"));
-        
-        Map<String, String> na003Data = getFile0.getSampleData("NA003");
+
+        Map<String, String> na003Data = getFile0.getSampleData(2);
         assertEquals("./.", na003Data.get("GT"));
         assertEquals(".", na003Data.get("AD"));
         assertEquals(".", na003Data.get("DP"));
         assertEquals(".", na003Data.get("GQ"));
         assertEquals(".", na003Data.get("PL"));
-        
-        Map<String, String> na004Data = getFile0.getSampleData("NA004");
+
+        Map<String, String> na004Data = getFile0.getSampleData(3);
         assertEquals("./.", na004Data.get("GT"));
         assertEquals(".", na004Data.get("AD"));
         assertEquals(".", na004Data.get("DP"));
         assertEquals(".", na004Data.get("GQ"));
         assertEquals(".", na004Data.get("PL"));
     }
-    
+
     @Test
     public void testParseInfo() {
-        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
-        source.setSamples(sampleNames);
-        String line ="1\t123456\t.\tT\tC,G\t110\tPASS\tAN=3;AC=1,2;AF=0.125,0.25;DP=63;NS=4;MQ=10685\tGT:AD:DP:GQ:PL\t" 
+        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\tAN=3;AC=1,2;AF=0.125,0.25;DP=63;NS=4;MQ=10685\tGT:AD:DP:GQ:PL\t"
                 + "0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t0/2:7,6:13:0:162,0,180"; // 4 samples
-        
+
         // Initialize expected variants
         Variant var0 = new Variant("1", 123456, 123456, "T", "C");
         VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
@@ -468,8 +476,8 @@ public class VariantVcfFactoryTest {
         Variant var1 = new Variant("1", 123456, 123456, "T", "G");
         VariantSourceEntry file1 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
         var1.addSourceEntry(file1);
-        
-        
+
+
         // Initialize expected samples
         Map<String, String> na001 = new HashMap<>();
         na001.put("GT", "0/1");
@@ -496,15 +504,15 @@ public class VariantVcfFactoryTest {
         na004.put("GQ", "0");
         na004.put("PL", "162,0,180");
 
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
-        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004);
 
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
-        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na001);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na002);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na003);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(na004);
 
 
         // Check proper conversion of samples
@@ -557,7 +565,8 @@ public class VariantVcfFactoryTest {
         line = "1\t1000\t.\tC\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
-        expResult.get(0).setIds(Collections.<String>emptySet());    // note!: we store a "." as an empty set, not a set with an empty string
+        expResult.get(0).setIds(
+                Collections.<String>emptySet());    // note!: we store a "." as an empty set, not a set with an empty string
         result = factory.create(source, line);
         assertEquals(expResult, result);
         assertEquals(expResult.get(0).getIds().size(), result.get(0).getIds().size());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
@@ -1,0 +1,565 @@
+package org.opencb.biodata.models.variant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Cristina Yenyxe Gonzalez Garcia &lt;cyenyxe@ebi.ac.uk&gt;
+ * @author Alejandro Aleman Ramos &lt;aaleman@cipf.es&gt;
+ * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
+ */
+public class VariantVcfFactoryTest {
+
+    private VariantSource source = new VariantSource("filename.vcf", "fileId", "studyId", "studyName");
+    private VariantFactory factory = new VariantVcfFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003");
+        source.setSamples(sampleNames);
+    }
+
+    @Test
+    public void testCreateVariantFromVcfSameLengthRefAlt() {
+        // Test when there are differences at the end of the sequence
+        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\t.";
+
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1005, "CACCC", "GACGG"));
+
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+
+        // Test when there are not differences at the end of the sequence
+        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\t.";
+
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1004, "CACC", "GACG"));
+
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCreateVariantFromVcfInsertionEmptyRef() {
+        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\t.";
+
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000 + "TGACGC".length() - 1, "", "TGACGC"));
+
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCreateVariantFromVcfDeletionEmptyAlt() {
+        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\t.";
+
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
+
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCreateVariantFromVcfIndelNotEmptyFields() {
+        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\t.";
+
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000 + "CGATT".length() - 1, "CGATT", "TAC"));
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tAT\tA\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1001, "T", ""));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tGATC\tG\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1003, "ATC", ""));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\t.\tATC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1002, "", "ATC"));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tA\tATC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1002, "", "TC"));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tAC\tACT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1002, 1002, "", "T"));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        // Printing those that are not currently managed
+        line = "1\t1000\trs123\tAT\tT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "A", ""));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tATC\tTC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "A", ""));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tATC\tAC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1001, "T", ""));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tAC\tATC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1001, 1001, "", "T"));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        
+        line = "1\t1000\trs123\tATC\tGC\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1001, "AT", "G"));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCreateVariantFromVcfCoLocatedVariants_MainFields() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
+        source.setSamples(sampleNames);
+
+        String line = "1\t10040\trs123\tTGACGTAACGATT\tT,TGACGTAACGGTT,TGACGTAATAC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/2"; // 4 samples
+
+        // Check proper conversion of main fields
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 10040, 10040 + "TGACGTAACGAT".length() - 1, "TGACGTAACGAT", ""));
+        expResult.add(new Variant("1", 10050, 10050 + "A".length() - 1, "A", "G"));
+        expResult.add(new Variant("1", 10048, 10048 + "CGATT".length() - 1, "CGATT", "TAC"));
+
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCreateVariant_Samples() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005");
+        source.setSamples(sampleNames);
+
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0/1\t0/.\t./1\t1/1"; // 5 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var0.addSourceEntry(file0);
+
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "0/0");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "0/1");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "0/.");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "./1");
+        Map<String, String> na005 = new HashMap<>();
+        na005.put("GT", "1/1");
+
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005);
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(source, line);
+        assertEquals(1, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+    }
+
+    @Test
+    public void testCreateVariantFromVcfMultiallelicVariants_Samples() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
+        source.setSamples(sampleNames);
+        String line ="1\t123456\t.\tT\tC,G\t110\tPASS\t.\tGT:AD:DP:GQ:PL\t0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t1/2:7,6:13:99:162,0,180"; // 4 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
+        VariantSourceEntry file1 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var1.addSourceEntry(file1);
+
+
+        // Initialize expected samples in variant 1 (alt allele C)
+        Map<String, String> na001_C = new HashMap<>();
+        na001_C.put("GT", "0/1");
+        na001_C.put("AD", "10,5");
+        na001_C.put("DP", "17");
+        na001_C.put("GQ", "94");
+        na001_C.put("PL", "94,0,286");
+        Map<String, String> na002_C = new HashMap<>();
+        na002_C.put("GT", "0/2");
+        na002_C.put("AD", "3,8");
+        na002_C.put("DP", "15");
+        na002_C.put("GQ", "43");
+        na002_C.put("PL", "222,0,43");
+        Map<String, String> na003_C = new HashMap<>();
+        na003_C.put("GT", "0/0");
+        na003_C.put("AD", ".");
+        na003_C.put("DP", "18");
+        na003_C.put("GQ", ".");
+        na003_C.put("PL", ".");
+        Map<String, String> na004_C = new HashMap<>();
+        na004_C.put("GT", "1/2");
+        na004_C.put("AD", "7,6");
+        na004_C.put("DP", "13");
+        na004_C.put("GQ", "99");
+        na004_C.put("PL", "162,0,180");
+
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_C);
+        
+        // Initialize expected samples in variant 2 (alt allele G)
+        Map<String, String> na001_G = new HashMap<>();
+        na001_G.put("GT", "0/2");
+        na001_G.put("AD", "10,5");
+        na001_G.put("DP", "17");
+        na001_G.put("GQ", "94");
+        na001_G.put("PL", "94,0,286");
+        Map<String, String> na002_G = new HashMap<>();
+        na002_G.put("GT", "0/1");
+        na002_G.put("AD", "3,8");
+        na002_G.put("DP", "15");
+        na002_G.put("GQ", "43");
+        na002_G.put("PL", "222,0,43");
+        Map<String, String> na003_G = new HashMap<>();
+        na003_G.put("GT", "0/0");
+        na003_G.put("AD", ".");
+        na003_G.put("DP", "18");
+        na003_G.put("GQ", ".");
+        na003_G.put("PL", ".");
+        Map<String, String> na004_G = new HashMap<>();
+        na004_G.put("GT", "2/1");
+        na004_G.put("AD", "7,6");
+        na004_G.put("DP", "13");
+        na004_G.put("GQ", "99");
+        na004_G.put("PL", "162,0,180");
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_G);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_G);
+
+
+        // Check proper conversion of samples and alternate alleles
+        List<Variant> result = factory.create(source, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(
+                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+        assertArrayEquals(new String[]{ "G" }, getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+
+        Variant getVar1 = result.get(1);
+        assertEquals(
+                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+        assertArrayEquals(new String[]{ "C" }, getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+    }
+
+    @Test
+    public void testCreateVariantFromVcfCoLocatedVariants_Samples() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004", "NA005", "NA006");
+        source.setSamples(sampleNames);
+        String line = "1\t10040\trs123\tT\tC,GC\t.\t.\t.\tGT:GL\t0/0:1,2,3,4,5,6,7,8,9,10\t0/1:1,2,3,4,5,6,7,8,9,10\t0/2:1,2,3,4,5,6,7,8,9,10\t1/1:1,2,3,4,5,6,7,8,9,10\t1/2:1,2,3,4,5,6,7,8,9,10\t2/2:1,2,3,4,5,6,7,8,9,10"; // 6 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 10050, 10050 + "GC".length() - 1, "T", "GC");
+        VariantSourceEntry file1 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var1.addSourceEntry(file1);
+
+        // Initialize expected samples in variant 1 (alt allele C)
+        Map<String, String> na001_C = new HashMap<>();
+        na001_C.put("GT", "0/0");
+        na001_C.put("GL", "1,1,1");
+        Map<String, String> na002_C = new HashMap<>();
+        na002_C.put("GT", "0/1");
+        na002_C.put("GL", "1,2,3");
+        Map<String, String> na003_C = new HashMap<>();
+        na003_C.put("GT", "0/2");
+        na003_C.put("GL", "1,4,6");
+        Map<String, String> na004_C = new HashMap<>();
+        na004_C.put("GT", "1/1");
+        na004_C.put("GL", "1,2,3");
+        Map<String, String> na005_C = new HashMap<>();
+        na005_C.put("GT", "1/2");
+        na005_C.put("GL", "3,5,6");
+        Map<String, String> na006_C = new HashMap<>();
+        na006_C.put("GT", "2/2");
+        na006_C.put("GL", "1,4,6");
+
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005_C);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(5), na006_C);
+
+        // TODO Initialize expected samples in variant 2 (alt allele GC)
+        Map<String, String> na001_GC = new HashMap<>();
+        na001_GC.put("GT", "0/0");
+        na001_GC.put("GL", "1,1,1");
+        Map<String, String> na002_GC = new HashMap<>();
+        na002_GC.put("GT", "0/2");
+        na002_GC.put("GL", "1,2,3");
+        Map<String, String> na003_GC = new HashMap<>();
+        na003_GC.put("GT", "0/1");
+        na003_GC.put("GL", "1,4,6");
+        Map<String, String> na004_GC = new HashMap<>();
+        na004_GC.put("GT", "2/2");
+        na004_GC.put("GL", "1,2,3");
+        Map<String, String> na005_GC = new HashMap<>();
+        na005_GC.put("GT", "2/1");
+        na005_GC.put("GL", "3,5,6");
+        Map<String, String> na006_GC = new HashMap<>();
+        na006_GC.put("GT", "1/1");
+        na006_GC.put("GL", "1,4,6");
+        
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(4), na005_GC);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(5), na006_GC);
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(source, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(
+                var0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+        assertArrayEquals(new String[]{ "GC" }, getVar0.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+
+        Variant getVar1 = result.get(1);
+        assertEquals(
+                var1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData(), 
+                getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSamplesData());
+        assertArrayEquals(new String[]{ "C" }, getVar1.getSourceEntry(source.getFileId(), source.getStudyId()).getSecondaryAlternates());
+    }
+    
+    @Test
+    public void testCreateVariantWithMissingGenotypes() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
+        source.setSamples(sampleNames);
+        String line = "1\t1407616\t.\tC\tG\t43.74\tPASS\t.\tGT:AD:DP:GQ:PL\t./.:.:.:.:.\t1/1:0,2:2:6:71,6,0\t./.:.:.:.:.\t./.:.:.:.:.";
+    
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 1407616, 1407616, "C", "G");
+        VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var0.addSourceEntry(file0);
+        
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "./.");
+        na001.put("AD", ".");
+        na001.put("DP", ".");
+        na001.put("GQ", ".");
+        na001.put("PL", ".");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "1/1");
+        na002.put("AD", "0,2");
+        na002.put("DP", "2");
+        na002.put("GQ", "6");
+        na002.put("PL", "71,6,0");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "./.");
+        na003.put("AD", ".");
+        na003.put("DP", ".");
+        na003.put("GQ", ".");
+        na003.put("PL", ".");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "./.");
+        na004.put("AD", ".");
+        na004.put("DP", ".");
+        na004.put("GQ", ".");
+        na004.put("PL", ".");
+        
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+        
+        
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(source, line);
+        assertEquals(1, result.size());
+
+        Variant getVar0 = result.get(0);
+        VariantSourceEntry getFile0 = getVar0.getSourceEntry(source.getFileId(), source.getStudyId());
+        
+        Map<String, String> na001Data = getFile0.getSampleData("NA001");
+        assertEquals("./.", na001Data.get("GT"));
+        assertEquals(".", na001Data.get("AD"));
+        assertEquals(".", na001Data.get("DP"));
+        assertEquals(".", na001Data.get("GQ"));
+        assertEquals(".", na001Data.get("PL"));
+        
+        Map<String, String> na002Data = getFile0.getSampleData("NA002");
+        assertEquals("1/1", na002Data.get("GT"));
+        assertEquals("0,2", na002Data.get("AD"));
+        assertEquals("2", na002Data.get("DP"));
+        assertEquals("6", na002Data.get("GQ"));
+        assertEquals("71,6,0", na002Data.get("PL"));
+        
+        Map<String, String> na003Data = getFile0.getSampleData("NA003");
+        assertEquals("./.", na003Data.get("GT"));
+        assertEquals(".", na003Data.get("AD"));
+        assertEquals(".", na003Data.get("DP"));
+        assertEquals(".", na003Data.get("GQ"));
+        assertEquals(".", na003Data.get("PL"));
+        
+        Map<String, String> na004Data = getFile0.getSampleData("NA004");
+        assertEquals("./.", na004Data.get("GT"));
+        assertEquals(".", na004Data.get("AD"));
+        assertEquals(".", na004Data.get("DP"));
+        assertEquals(".", na004Data.get("GQ"));
+        assertEquals(".", na004Data.get("PL"));
+    }
+    
+    @Test
+    public void testParseInfo() {
+        List<String> sampleNames = Arrays.asList("NA001", "NA002", "NA003", "NA004");
+        source.setSamples(sampleNames);
+        String line ="1\t123456\t.\tT\tC,G\t110\tPASS\tAN=3;AC=1,2;AF=0.125,0.25;DP=63;NS=4;MQ=10685\tGT:AD:DP:GQ:PL\t" 
+                + "0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t0/2:7,6:13:0:162,0,180"; // 4 samples
+        
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
+        VariantSourceEntry file1 = new VariantSourceEntry(source.getFileId(), source.getStudyId());
+        var1.addSourceEntry(file1);
+        
+        
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "0/1");
+        na001.put("AD", "10,5");
+        na001.put("DP", "17");
+        na001.put("GQ", "94");
+        na001.put("PL", "94,0,286");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "0/1");
+        na002.put("AD", "3,8");
+        na002.put("DP", "15");
+        na002.put("GQ", "43");
+        na002.put("PL", "222,0,43");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "0/0");
+        na003.put("AD", ".");
+        na003.put("DP", "18");
+        na003.put("GQ", ".");
+        na003.put("PL", ".");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "0/1");
+        na004.put("AD", "7,6");
+        na004.put("DP", "13");
+        na004.put("GQ", "0");
+        na004.put("PL", "162,0,180");
+
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
+        var0.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(0), na001);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(1), na002);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(2), na003);
+        var1.getSourceEntry(source.getFileId(), source.getStudyId()).addSampleData(sampleNames.get(3), na004);
+
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(source, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        VariantSourceEntry getFile0 = getVar0.getSourceEntry(source.getFileId(), source.getStudyId());
+        assertEquals(4, Integer.parseInt(getFile0.getAttribute("NS")));
+//        assertEquals(2, Integer.parseInt(getFile0.getAttribute("AN")));
+        assertEquals(1, Integer.parseInt(getFile0.getAttribute("AC")));
+        assertEquals(0.125, Double.parseDouble(getFile0.getAttribute("AF")), 1e-8);
+        assertEquals(63, Integer.parseInt(getFile0.getAttribute("DP")));
+        assertEquals(10685, Integer.parseInt(getFile0.getAttribute("MQ")));
+        assertEquals(1, Integer.parseInt(getFile0.getAttribute("MQ0")));
+
+        Variant getVar1 = result.get(1);
+        VariantSourceEntry getFile1 = getVar1.getSourceEntry(source.getFileId(), source.getStudyId());
+        assertEquals(4, Integer.parseInt(getFile1.getAttribute("NS")));
+//        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AN")));
+        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AC")));
+        assertEquals(0.25, Double.parseDouble(getFile1.getAttribute("AF")), 1e-8);
+        assertEquals(63, Integer.parseInt(getFile1.getAttribute("DP")));
+        assertEquals(10685, Integer.parseInt(getFile1.getAttribute("MQ")));
+        assertEquals(1, Integer.parseInt(getFile1.getAttribute("MQ0")));
+    }
+
+    @Test
+    public void testVariantIds() {
+
+        // test that an ID is properly handled
+        String line = "1\t1000\trs123\tC\tT\t.\t.\t.";
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(Collections.singleton("rs123"));
+        List<Variant> result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
+
+        // test that the ';' is used as the ID separator (as of VCF 4.2)
+        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(new HashSet<>(Arrays.asList("rs123", "rs456")));
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds(), result.get(0).getIds());
+
+        // test that a missing ID ('.') is not added to the IDs set
+        line = "1\t1000\t.\tC\tT\t.\t.\t.";
+        expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "C", "T"));
+        expResult.get(0).setIds(Collections.<String>emptySet());    // note!: we store a "." as an empty set, not a set with an empty string
+        result = factory.create(source, line);
+        assertEquals(expResult, result);
+        assertEquals(expResult.get(0).getIds().size(), result.get(0).getIds().size());
+    }
+}


### PR DESCRIPTION
Before:
===

with a file of 10K samples:
total memory: around 2.2 GB
900K instances (20%) of String (most of them are "0|0")
900K instances (20%) of char[] (most of them are "0|0")
char[] + String occupy 25% the total memory

After:
===
removed useless code and using String::intern

the memory usage was reduced to a 77% of the previous memory usage.

the intern method is used to reuse the string of the genotype
from the pool of strings.

However, there are still lots of maps that have different pointers
pointing to the same strings.

with a file of 10K samples:
total memory: around 1.7 GB
1M instances (32%) of TreeMap$Entry
1M instances (46%) of TreeMap
these two occupy 78% the total memory