### PR TITLE
Minor stats improvement

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
@@ -33,10 +33,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class Application {
 
+
     private static final Logger log = LoggerFactory.getLogger(Application.class);
     public static final String VARIANT_WRITER_MONGO_PROFILE = "variant-writer-mongo";
     public static final String VARIANT_ANNOTATION_MONGO_PROFILE = "variant-annotation-mongo";
     public static final String PRODUCTION_PROFILE = "production";
+    public static final String MONGO_EXPERIMENTAL = "experimental";
 
     public static void main(String[] args) throws Exception {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,34 @@
  */
 package uk.ac.ebi.eva.pipeline;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 
 /**
- * Main entry point. spring boot takes care of autowiring everything with the JobLauncherCommandLineRunner.
- * By default, no job will be run on startup. Use this to launch any job:
+ * Main entry point. Spring Boot takes care of autowiring everything with the JobLauncherCommandLineRunner.
+ * In order to select which job to run on start up, run a command like the following:
  * <p>
- * java -jar target/eva-pipeline-0.1.jar --spring.batch.job.names=load-genotyped-vcf
+ * java -jar target/eva-pipeline.jar --spring.batch.job.names=load-genotyped-vcf
  * <p>
- * append any parameter needed.
+ * Append any parameter as needed.
  * TODO document all parameters
  */
 @SpringBootApplication
 public class Application {
 
-
-    private static final Logger log = LoggerFactory.getLogger(Application.class);
     public static final String VARIANT_WRITER_MONGO_PROFILE = "variant-writer-mongo";
     public static final String VARIANT_ANNOTATION_MONGO_PROFILE = "variant-annotation-mongo";
+
+    /**
+     * Profile for features that shall run in production only, such as a persistent job repository.
+     */
     public static final String PRODUCTION_PROFILE = "production";
-    public static final String MONGO_EXPERIMENTAL = "experimental";
+
+    /**
+     * Profile for experimental features that shall not be active unless explicitly requested.
+     */
+    public static final String MONGO_EXPERIMENTAL_PROFILE = "experimental";
 
     public static void main(String[] args) throws Exception {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/model/PopulationStatistics.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/model/PopulationStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,11 @@ import uk.ac.ebi.eva.pipeline.Application;
 import java.util.Map;
 
 /**
- * setters have package visibility, the user should use the constructor.
+ * Statistics related to a set of samples for a given variant.
+ * <p>
+ * Setters have package visibility, the user should use the constructor to instantiate valid objects.
  */
-@Profile(Application.MONGO_EXPERIMENTAL)
+@Profile(Application.MONGO_EXPERIMENTAL_PROFILE)
 @Document
 @CompoundIndexes({
     @CompoundIndex(name = "vscid", def = "{'chr': 1, 'start': 1, 'ref': 1, 'alt': 1, 'sid': 1, 'cid': 1}", unique = true)
@@ -130,6 +132,7 @@ public class PopulationStatistics {
     void setAlternate(String alternate) {
         this.alternate = alternate;
     }
+
     public String getCohortId() {
         return cohortId;
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/model/PopulationStatistics.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/model/PopulationStatistics.java
@@ -15,17 +15,21 @@
  */
 package uk.ac.ebi.eva.pipeline.model;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import uk.ac.ebi.eva.pipeline.Application;
+
 import java.util.Map;
 
 /**
  * setters have package visibility, the user should use the constructor.
  */
+@Profile(Application.MONGO_EXPERIMENTAL)
 @Document
 @CompoundIndexes({
     @CompoundIndex(name = "vscid", def = "{'chr': 1, 'start': 1, 'ref': 1, 'alt': 1, 'sid': 1, 'cid': 1}", unique = true)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
@@ -20,6 +20,7 @@ import org.opencb.biodata.models.variant.VariantStudy;
 import org.opencb.datastore.core.ObjectMap;
 import org.opencb.opencga.lib.common.Config;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
+import org.opencb.opencga.storage.core.variant.stats.VariantStatisticsManager;
 import org.opencb.opencga.storage.mongodb.variant.MongoDBVariantStorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,6 +179,7 @@ public class JobOptions {
         variantOptions.put(VariantStorageManager.INCLUDE_SRC, includeSourceLine);
         variantOptions.put("compressExtension", compressExtension);
         variantOptions.put(VariantStorageManager.ANNOTATE, annotate);
+        variantOptions.put(VariantStatisticsManager.BATCH_SIZE, chunkSize);
 
         variantOptions.put(VariantStorageManager.DB_NAME, dbName);
         variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME, dbName);


### PR DESCRIPTION
 commits:
- fix bug: disabling the creation of (unused) popStats collection. There is a collection "populationStatistics" that we are not using yet, but the spring framework is preparing the indexes in that collection. 
- allow to tune the batch size for stats calculation. A big study (10K+ samples) was having memory troubles, so it is useful to use our `config.chunk.size` to also configure the batchsize in opencga's statistics calculation. if the memory usage is too high, setting a lower chunk size (such as 50) reduces the memory usage in the variants load step and the stats calculation step.