### PR TITLE
Annotation loader step parameters validator eva 551

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantAnnotationReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantAnnotationReaderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class VariantAnnotationReaderConfiguration {
     @Bean(VARIANT_ANNOTATION_READER)
     @StepScope
     public ItemStreamReader<VariantAnnotation> variantAnnotationReader(JobOptions jobOptions) {
-        return new AnnotationFlatFileReader(jobOptions.getPipelineOptions().getString(JobOptions.VEP_OUTPUT));
+        return new AnnotationFlatFileReader(jobOptions.getVepOutput());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
@@ -16,6 +16,7 @@
 
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
+import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -76,12 +77,16 @@ public class GeneLoaderStep {
     public Step genesLoadStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + GENES_LOAD_STEP + "'");
 
+        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
+        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
+
         return stepBuilderFactory.get(GENES_LOAD_STEP)
                 .<FeatureCoordinates, FeatureCoordinates>chunk(jobOptions.getPipelineOptions().getInt(JobParametersNames.CONFIG_CHUNK_SIZE))
                 .reader(reader)
                 .processor(new GeneFilterProcessor())
                 .writer(writer)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
+                .allowStartIfComplete(startIfcomplete)
                 .listener(new SkippedItemListener())
                 .build();
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
+import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -64,11 +65,15 @@ public class VariantLoaderStep {
     public Step loadVariantsStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + LOAD_VARIANTS_STEP + "'");
 
+        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
+        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
+
         return stepBuilderFactory.get(LOAD_VARIANTS_STEP)
                 .<Variant, Variant>chunk(jobOptions.getPipelineOptions().getInt(JobParametersNames.CONFIG_CHUNK_SIZE))
                 .reader(reader)
                 .writer(variantWriter)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
+                .allowStartIfComplete(startIfcomplete)
                 .listener(new SkippedItemListener())
                 .build();
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@ import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigRestartabilityAllowValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
-import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
-import uk.ac.ebi.eva.pipeline.parameters.validation.InputVcfIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OptionalValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OutputDirAnnotationValidator;
 
@@ -35,18 +33,14 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Validates the job parameters necessary to execute a {@link uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep}
- * <p>
- * The parameters OUTPUT_DIR_ANNOTATION, INPUT_STUDY_ID and INPUT_VCF_ID are used to build the VEP input option
- * {@see uk.ac.ebi.eva.pipeline.configuration.JobOptions#loadPipelineOptions()}
+ * Validates the job parameters necessary to execute an {@link uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep}
  */
 public class AnnotationLoaderStepParametersValidator extends DefaultJobParametersValidator {
+
     public AnnotationLoaderStepParametersValidator() {
         super(new String[]{JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
-                      JobParametersNames.DB_NAME,
-                      JobParametersNames.INPUT_STUDY_ID,
-                      JobParametersNames.INPUT_VCF_ID,
-                      JobParametersNames.OUTPUT_DIR_ANNOTATION},
+                           JobParametersNames.DB_NAME,
+                           JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
     }
 
@@ -60,8 +54,6 @@ public class AnnotationLoaderStepParametersValidator extends DefaultJobParameter
         final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
                 new DbCollectionsVariantsNameValidator(),
                 new DbNameValidator(),
-                new InputStudyIdValidator(),
-                new InputVcfIdValidator(),
                 new OutputDirAnnotationValidator(),
                 new OptionalValidator(new ConfigRestartabilityAllowValidator(),
                                       JobParametersNames.CONFIG_RESTARTABILITY_ALLOW),

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters.validation.step;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.JobParametersValidator;
+import org.springframework.batch.core.job.CompositeJobParametersValidator;
+import org.springframework.batch.core.job.DefaultJobParametersValidator;
+
+import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigRestartabilityAllowValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.InputVcfIdValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.OptionalValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.OutputDirAnnotationValidator;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Validates the job parameters necessary to execute a {@link uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep}
+ * <p>
+ * The parameters OUTPUT_DIR_ANNOTATION, INPUT_STUDY_ID and INPUT_VCF_ID are used to build the VEP input option
+ * {@see uk.ac.ebi.eva.pipeline.configuration.JobOptions#loadPipelineOptions()}
+ */
+public class AnnotationLoaderStepParametersValidator extends DefaultJobParametersValidator {
+    public AnnotationLoaderStepParametersValidator() {
+        super(new String[]{JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
+                      JobParametersNames.DB_NAME,
+                      JobParametersNames.INPUT_STUDY_ID,
+                      JobParametersNames.INPUT_VCF_ID,
+                      JobParametersNames.OUTPUT_DIR_ANNOTATION},
+              new String[]{});
+    }
+
+    @Override
+    public void validate(JobParameters parameters) throws JobParametersInvalidException {
+        super.validate(parameters);
+        compositeJobParametersValidator().validate(parameters);
+    }
+
+    private CompositeJobParametersValidator compositeJobParametersValidator() {
+        final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
+                new DbCollectionsVariantsNameValidator(),
+                new DbNameValidator(),
+                new InputStudyIdValidator(),
+                new InputVcfIdValidator(),
+                new OutputDirAnnotationValidator(),
+                new OptionalValidator(new ConfigRestartabilityAllowValidator(),
+                                      JobParametersNames.CONFIG_RESTARTABILITY_ALLOW),
+                new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE)
+        );
+
+        CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();
+        compositeJobParametersValidator.setValidators(jobParametersValidators);
+        return compositeJobParametersValidator;
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VariantLoaderStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VariantLoaderStepParametersValidator.java
@@ -23,6 +23,7 @@ import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigRestartabilityAllowValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
@@ -36,7 +37,7 @@ import java.util.List;
 
 /**
  * Validates the job parameters necessary to execute a
- * {@link uk.ac.ebi.eva.pipeline.jobs.steps.PopulationStatisticsGeneratorStep}
+ * {@link uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep}
  */
 public class VariantLoaderStepParametersValidator extends DefaultJobParametersValidator {
 
@@ -65,7 +66,8 @@ public class VariantLoaderStepParametersValidator extends DefaultJobParametersVa
                 new InputVcfIdValidator(),
                 new InputVcfValidator(),
                 new InputVcfAggregationValidator(),
-                new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE)
+                new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE),
+                new OptionalValidator(new ConfigRestartabilityAllowValidator(), JobParametersNames.CONFIG_RESTARTABILITY_ALLOW)
         );
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
@@ -22,6 +22,7 @@ import org.springframework.batch.core.job.CompositeJobParametersValidator;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigRestartabilityAllowValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
@@ -58,13 +59,13 @@ public class VepInputGeneratorStepParametersValidator extends DefaultJobParamete
 
     private CompositeJobParametersValidator compositeJobParametersValidator() {
         final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
-                new OptionalValidator(new ConfigRestartabilityAllowValidator(),
-                                      JobParametersNames.CONFIG_RESTARTABILITY_ALLOW),
                 new DbCollectionsVariantsNameValidator(),
                 new DbNameValidator(),
                 new InputStudyIdValidator(),
                 new InputVcfIdValidator(),
-                new OutputDirAnnotationValidator()
+                new OutputDirAnnotationValidator(),
+                new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE),
+                new OptionalValidator(new ConfigRestartabilityAllowValidator(), JobParametersNames.CONFIG_RESTARTABILITY_ALLOW)
         );
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters.validation.step;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+
+import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Tests that the arguments necessary to run a {@link uk.ac.ebi.eva.pipeline.jobs.steps.AnnotationLoaderStep} are
+ * correctly validated
+ */
+public class AnnotationLoaderStepParametersValidatorTest {
+    private AnnotationLoaderStepParametersValidator validator;
+
+    @Rule
+    public PipelineTemporaryFolderRule temporaryFolder = new PipelineTemporaryFolderRule();
+
+    private Map<String, JobParameter> requiredParameters;
+
+    private Map<String, JobParameter> optionalParameters;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new AnnotationLoaderStepParametersValidator();
+        final String dir = temporaryFolder.getRoot().getCanonicalPath();
+
+        requiredParameters = new TreeMap<>();
+        requiredParameters.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
+                               new JobParameter("dbCollectionsVariantName"));
+        requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("dbName"));
+        requiredParameters.put(JobParametersNames.INPUT_STUDY_ID, new JobParameter("inputStudyId"));
+        requiredParameters.put(JobParametersNames.INPUT_VCF_ID, new JobParameter("inputVcfId"));
+        requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
+
+        optionalParameters = new TreeMap<>();
+        optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
+        optionalParameters.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, new JobParameter("true"));
+    }
+
+    @Test
+    public void allJobParametersAreValid() throws JobParametersInvalidException, IOException {
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test
+    public void allJobParametersIncludingOptionalAreValid() throws JobParametersInvalidException, IOException {
+        Map<String, JobParameter> parameters = new TreeMap<>();
+        parameters.putAll(requiredParameters);
+        parameters.putAll(optionalParameters);
+        validator.validate(new JobParameters(parameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbCollectionsVariantsNameIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbNameIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.DB_NAME);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void inputStudyIdIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void inputVcfIdIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_VCF_ID);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void outputDirAnnotationIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.OUTPUT_DIR_ANNOTATION);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ public class AnnotationLoaderStepParametersValidatorTest {
         requiredParameters.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
                                new JobParameter("dbCollectionsVariantName"));
         requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("dbName"));
-        requiredParameters.put(JobParametersNames.INPUT_STUDY_ID, new JobParameter("inputStudyId"));
-        requiredParameters.put(JobParametersNames.INPUT_VCF_ID, new JobParameter("inputVcfId"));
         requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
 
         optionalParameters = new TreeMap<>();
@@ -83,18 +81,6 @@ public class AnnotationLoaderStepParametersValidatorTest {
     @Test(expected = JobParametersInvalidException.class)
     public void dbNameIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.DB_NAME);
-        validator.validate(new JobParameters(requiredParameters));
-    }
-
-    @Test(expected = JobParametersInvalidException.class)
-    public void inputStudyIdIsRequired() throws JobParametersInvalidException, IOException {
-        requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
-        validator.validate(new JobParameters(requiredParameters));
-    }
-
-    @Test(expected = JobParametersInvalidException.class)
-    public void inputVcfIdIsRequired() throws JobParametersInvalidException, IOException {
-        requiredParameters.remove(JobParametersNames.INPUT_VCF_ID);
         validator.validate(new JobParameters(requiredParameters));
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VariantLoaderStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VariantLoaderStepParametersValidatorTest.java
@@ -60,6 +60,7 @@ public class VariantLoaderStepParametersValidatorTest {
 
         optionalParameters = new TreeMap<>();
         optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
+        optionalParameters.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, new JobParameter("true"));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidatorTest.java
@@ -58,6 +58,7 @@ public class VepInputGeneratorStepParametersValidatorTest {
         requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
 
         optionalParameters = new TreeMap<>();
+        optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
         optionalParameters.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, new JobParameter("true"));
     }
 


### PR DESCRIPTION
- New parameter validator for AnnotationLoaderStep
- Added CONFIG_RESTARTABILITY_ALLOW and CONFIG_CHUNK_SIZE where missing
- To decide if in VepAnnotationGeneratorStepParametersValidator we have to check the CONFIG_RESTARTABILITY_ALLOW parameter since it is used outside in GenerateVepAnnotationStep.

EVA-551