### PR TITLE
EVA-587 Fixed structure of "meta" field in "files" collection

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/commons/models/data/VariantSourceEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/data/VariantSourceEntity.java
@@ -33,65 +33,82 @@ import java.util.Map;
 @Document
 public class VariantSourceEntity {
 
-    @Field(value = "fname")
-    private String fileName;
+    public final static String FILEID_FIELD = "fid";
+    public final static String FILENAME_FIELD = "fname";
+    public final static String STUDYID_FIELD = "sid";
+    public final static String STUDYNAME_FIELD = "sname";
+    public final static String STUDYTYPE_FIELD = "stype";
+    public final static String AGGREGATION_FIELD = "aggregation";
+    public final static String DATE_FIELD = "date";
+    public final static String SAMPLES_FIELD = "samp";
 
-    @Field(value = "fid")
+    public final static String STATISTICS_FIELD = "st";
+    public final static String STATISTICS_NUMSAMPLES_FIELD = "nSamp";
+    public final static String STATISTICS_NUMVARIANTS_FIELD = "nVar";
+    public final static String STATISTICS_NUMSNPS_FIELD = "nSnp";
+    public final static String STATISTICS_NUMINDELS_FIELD = "nIndel";
+    public final static String STATISTICS_NUMSTRUCTURAL_FIELD = "nSv";
+    public final static String STATISTICS_NUMPASSFILTERS_FIELD = "nPass";
+    public final static String STATISTICS_NUMTRANSITIONS_FIELD = "nTi";
+    public final static String STATISTICS_NUMTRANSVERSIONS_FIELD = "nTv";
+    public final static String STATISTICS_MEANQUALITY_FIELD = "meanQ";
+
+    public final static String METADATA_FIELD = "meta";
+    public final static String METADATA_FILEFORMAT_FIELD = "fileformat";
+    public final static String METADATA_HEADER_FIELD = "header";
+
+
+    @Field(value = FILEID_FIELD)
     private String fileId;
 
-    @Field(value = "sid")
+    @Field(value = FILENAME_FIELD)
+    private String fileName;
+
+    @Field(value = STUDYID_FIELD)
     private String studyId;
 
-    @Field(value = "sname")
+    @Field(value = STUDYNAME_FIELD)
     private String studyName;
 
-    @Field(value = "samp")
-    private Map<String, Integer> samplesPosition;
-
-    @Field(value = "meta")
-    private Map<String, Object> metadata;
-
-    @Field(value = "stype")
+    @Field(value = STUDYTYPE_FIELD)
     private VariantStudy.StudyType type;
 
-    @Field(value = "st")
-    private VariantGlobalStats stats;
-
-    @Field(value = "date")
-    private Date date;
-
-    @Field(value = "aggregation")
+    @Field(value = AGGREGATION_FIELD)
     private VariantSource.Aggregation aggregation;
 
-    public VariantSourceEntity(String fileName, String fileId, String studyId, String studyName,
-                               Map<String, Integer> samplesPosition,
-                               Map<String, Object> metadata, VariantStudy.StudyType type,
-                               VariantGlobalStats stats,
-                               VariantSource.Aggregation aggregation) {
-        this.fileName = fileName;
+    @Field(value = DATE_FIELD)
+    private Date date;
+
+    @Field(value = SAMPLES_FIELD)
+    private Map<String, Integer> samplesPosition;
+
+    @Field(value = METADATA_FIELD)
+    private Map<String, Object> metadata;
+
+    @Field(value = STATISTICS_FIELD)
+    private VariantGlobalStats stats;
+
+
+    public VariantSourceEntity(String fileId, String fileName, String studyId, String studyName,
+                               VariantStudy.StudyType type, VariantSource.Aggregation aggregation,
+                               Map<String, Integer> samplesPosition, Map<String, Object> metadata,
+                               VariantGlobalStats stats) {
         this.fileId = fileId;
+        this.fileName = fileName;
         this.studyId = studyId;
         this.studyName = studyName;
+        this.type = type;
+        this.aggregation = aggregation;
         this.samplesPosition = samplesPosition;
         this.metadata = metadata;
-        this.type = type;
         this.stats = stats;
-        this.aggregation = aggregation;
         this.date = Calendar.getInstance().getTime();
     }
 
     public VariantSourceEntity(VariantSource source) {
-        this(source.getFileName(), source.getFileId(), source.getStudyId(), source.getStudyName(),
-             source.getSamplesPosition(), source.getMetadata(), source.getType(), source.getStats(),
-             source.getAggregation());
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
+        this(source.getFileId(), source.getFileName(), source.getStudyId(), source.getStudyName(),
+             source.getType(), source.getAggregation(), source.getSamplesPosition(), source.getMetadata(),
+             source.getStats());
     }
 
     public String getFileId() {
@@ -100,6 +117,14 @@ public class VariantSourceEntity {
 
     public void setFileId(String fileId) {
         this.fileId = fileId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
     }
 
     public String getStudyId() {
@@ -118,6 +143,30 @@ public class VariantSourceEntity {
         this.studyName = studyName;
     }
 
+    public VariantStudy.StudyType getType() {
+        return type;
+    }
+
+    public void setType(VariantStudy.StudyType type) {
+        this.type = type;
+    }
+
+    public VariantSource.Aggregation getAggregation() {
+        return aggregation;
+    }
+
+    public void setAggregation(VariantSource.Aggregation aggregation) {
+        this.aggregation = aggregation;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
     public Map<String, Integer> getSamplesPosition() {
         return samplesPosition;
     }
@@ -134,14 +183,6 @@ public class VariantSourceEntity {
         this.metadata = metadata;
     }
 
-    public VariantStudy.StudyType getType() {
-        return type;
-    }
-
-    public void setType(VariantStudy.StudyType type) {
-        this.type = type;
-    }
-
     public VariantGlobalStats getStats() {
         return stats;
     }
@@ -150,19 +191,4 @@ public class VariantSourceEntity {
         this.stats = stats;
     }
 
-    public Date getDate() {
-        return date;
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
-    }
-
-    public VariantSource.Aggregation getAggregation() {
-        return aggregation;
-    }
-
-    public void setAggregation(VariantSource.Aggregation aggregation) {
-        this.aggregation = aggregation;
-    }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VcfHeaderReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VcfHeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,8 @@ public class VcfHeaderReader implements ItemReader<VariantSourceEntity> {
 
     /**
      * The header of the VCF can be retrieved using `source.getMetadata().get(VARIANT_FILE_HEADER_KEY)`.
-     * The "variantFileHeader" is required by the converter
-     * {@link org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantSourceConverter}, which will
-     * store it in mongo as "header".
      */
-    public static final String VARIANT_FILE_HEADER_KEY = "variantFileHeader";
+    public static final String VARIANT_FILE_HEADER_KEY = "header";
 
     private final File file;
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -86,19 +86,19 @@ public class VariantSourceEntityMongoWriterTest {
         while (cursor.hasNext()) {
             count++;
             DBObject next = cursor.next();
-            assertNotNull(next.get("fname"));
-            assertNotNull(next.get("fid"));
-            assertNotNull(next.get("sid"));
-            assertNotNull(next.get("sname"));
-            assertNotNull(next.get("samp"));
-            assertNotNull(next.get("stype"));
-            assertNotNull(next.get("date"));
-            assertNotNull(next.get("aggregation"));
+            assertNotNull(next.get(VariantSourceEntity.FILEID_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.FILENAME_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.STUDYID_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.STUDYNAME_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.STUDYTYPE_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.AGGREGATION_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.SAMPLES_FIELD));
+            assertNotNull(next.get(VariantSourceEntity.DATE_FIELD));
 
-            DBObject meta = (DBObject) next.get("meta");
+            DBObject meta = (DBObject) next.get(VariantSourceEntity.METADATA_FIELD);
             assertNotNull(meta);
-            assertNotNull(meta.get("fileformat"));
-            assertNotNull(meta.get("header"));
+            assertNotNull(meta.get(VariantSourceEntity.METADATA_FILEFORMAT_FIELD));
+            assertNotNull(meta.get(VariantSourceEntity.METADATA_HEADER_FIELD));
             assertNotNull(meta.get("ALT"));
             assertNotNull(meta.get("FILTER"));
             assertNotNull(meta.get("INFO"));

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import java.io.File;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResource;
 import static uk.ac.ebi.eva.utils.MongoDBHelper.getMongoOperations;
 
@@ -86,15 +86,23 @@ public class VariantSourceEntityMongoWriterTest {
         while (cursor.hasNext()) {
             count++;
             DBObject next = cursor.next();
-            assertTrue(next.get("fname") != null);
-            assertTrue(next.get("fid") != null);
-            assertTrue(next.get("sid") != null);
-            assertTrue(next.get("sname") != null);
-            assertTrue(next.get("samp") != null);
-            assertTrue(next.get("meta") != null);
-            assertTrue(next.get("stype") != null);
-            assertTrue(next.get("date") != null);
-            assertTrue(next.get("aggregation") != null);
+            assertNotNull(next.get("fname"));
+            assertNotNull(next.get("fid"));
+            assertNotNull(next.get("sid"));
+            assertNotNull(next.get("sname"));
+            assertNotNull(next.get("samp"));
+            assertNotNull(next.get("stype"));
+            assertNotNull(next.get("date"));
+            assertNotNull(next.get("aggregation"));
+
+            DBObject meta = (DBObject) next.get("meta");
+            assertNotNull(meta);
+            assertNotNull(meta.get("fileformat"));
+            assertNotNull(meta.get("header"));
+            assertNotNull(meta.get("ALT"));
+            assertNotNull(meta.get("FILTER"));
+            assertNotNull(meta.get("INFO"));
+            assertNotNull(meta.get("FORMAT"));
         }
         assertEquals(1, count);
     }


### PR DESCRIPTION
With the change to a straightforward entity writing, the header dump in the "files" collection began to be written to "meta.variantFileHeader" instead of the correct "meta.header". This behavior has been reverted and a new test added.

The order of the `VariantSourceEntity` class attributes has been slightly modified to keep closer those that are related.