### PR TITLE
EVA-587 Mapping dots in Mongo keys to another character

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/VariantToDBObjectConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/VariantToDBObjectConverter.java
@@ -25,13 +25,12 @@ import org.springframework.core.convert.converter.Converter;
 
 import uk.ac.ebi.eva.commons.models.data.Variant;
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntry;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static uk.ac.ebi.eva.utils.MongoDBHelper.buildStorageId;
 
 /**
  * Converts Variants into MongoDb objects. Implements spring's interface of converter.
@@ -117,7 +116,7 @@ public class VariantToDBObjectConverter implements Converter<Variant, DBObject> 
 
     @Override
     public DBObject convert(Variant object) {
-        String id = buildStorageId(object.getChromosome(), object.getStart(), object.getReference(),
+        String id = MongoDBHelper.buildStorageId(object.getChromosome(), object.getStart(), object.getReference(),
                                    object.getAlternate());
 
         BasicDBObject mongoVariant = new BasicDBObject("_id", id)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/MongoConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/MongoConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.configuration;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
+
+import uk.ac.ebi.eva.utils.MongoConnection;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
+
+/**
+ * Utility class dealing with MongoDB connections using pipeline options
+ */
+@Configuration
+public class MongoConfiguration {
+
+    @Autowired
+    private MongoMappingContext mongoMappingContext;
+
+    @Bean
+    public MongoMappingContext mongoMappingContext() {
+        return new MongoMappingContext();
+    }
+
+    public MongoOperations getDefaultMongoOperations(String database) throws UnknownHostException {
+        MongoClient mongoClient = new MongoClient();
+        mongoClient.setReadPreference(ReadPreference.primary());
+        MongoDbFactory mongoFactory = getMongoDbFactory(mongoClient, database);
+        MongoTemplate mongoTemplate = new MongoTemplate(mongoFactory, getMappingMongoConverter(mongoFactory));
+        return mongoTemplate;
+    }
+
+    public MongoOperations getMongoOperations(String database, MongoConnection connection) 
+            throws UnknownHostException {
+        MongoClient mongoClient = getMongoClient(connection);
+        MongoDbFactory mongoFactory = getMongoDbFactory(mongoClient, database);
+        MongoTemplate mongoTemplate = new MongoTemplate(mongoFactory, getMappingMongoConverter(mongoFactory));
+        return mongoTemplate;
+    }
+    
+    public MongoClient getMongoClient(MongoConnection connection) throws UnknownHostException {
+        String authenticationDatabase = null;
+        String user = null;
+        String password = null;
+        MongoClient mongoClient;
+        
+        // The Mongo API is not happy to deal with empty strings for authentication DB, user and password
+        if (connection.getAuthenticationDatabase() != null && !connection.getAuthenticationDatabase().trim().isEmpty()) {
+            authenticationDatabase = connection.getAuthenticationDatabase();
+        }
+        if (connection.getUser() != null && !connection.getUser().trim().isEmpty()) {
+            user = connection.getUser();
+        }
+        if (connection.getPassword() != null && !connection.getPassword().trim().isEmpty()) {
+            password = connection.getPassword();
+        }
+        
+        if (user == null || password == null) {
+            mongoClient = new MongoClient(MongoDBHelper.parseServerAddresses(connection.getHosts()));
+        } else {
+            mongoClient = new MongoClient(
+                    MongoDBHelper.parseServerAddresses(connection.getHosts()),
+                    Collections.singletonList(MongoCredential.createCredential(connection.getUser(),
+                            authenticationDatabase, connection.getPassword().toCharArray())));
+        }
+        mongoClient.setReadPreference(MongoDBHelper.getMongoTemplateReadPreferences(connection.getReadPreference()));
+
+        return mongoClient;
+    }
+
+    private MongoDbFactory getMongoDbFactory(MongoClient client, String database) {
+        return new SimpleMongoDbFactory(client, database);
+    }
+
+    private MappingMongoConverter getMappingMongoConverter(MongoDbFactory mongoFactory) {
+        DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoFactory);
+        MappingMongoConverter mongoConverter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+
+        // Customization: replace dots with pound sign
+        mongoConverter.setMapKeyDotReplacement("£");
+
+        return mongoConverter;
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/MongoConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/MongoConfiguration.java
@@ -92,7 +92,7 @@ public class MongoConfiguration {
                     Collections.singletonList(MongoCredential.createCredential(connection.getUser(),
                             authenticationDatabase, connection.getPassword().toCharArray())));
         }
-        mongoClient.setReadPreference(MongoDBHelper.getMongoTemplateReadPreferences(connection.getReadPreference()));
+        mongoClient.setReadPreference(connection.getReadPreference());
 
         return mongoClient;
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,11 @@ package uk.ac.ebi.eva.pipeline.configuration.readers;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 
@@ -29,6 +32,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIA
  * Configuration to inject a NonannotatedVariants bean that reads from a mongo database in the pipeline
  */
 @Configuration
+@Import({ MongoDBHelper.class })
 public class NonAnnotatedVariantsMongoReaderConfiguration {
 
     @Bean(NON_ANNOTATED_VARIANTS_READER)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -16,9 +16,11 @@
 package uk.ac.ebi.eva.pipeline.configuration.readers;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
@@ -35,13 +37,16 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIA
 @Import({ MongoDBHelper.class })
 public class NonAnnotatedVariantsMongoReaderConfiguration {
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Bean(NON_ANNOTATED_VARIANTS_READER)
     @StepScope
     public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(JobOptions jobOptions)
             throws UnknownHostException {
-        return new NonAnnotatedVariantsMongoReader(jobOptions.getDbName(),
-                jobOptions.getDbCollectionsVariantsName(),
-                jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                           jobOptions.getMongoConnection());
+        return new NonAnnotatedVariantsMongoReader(mongoOperations, jobOptions.getDbCollectionsVariantsName());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -22,9 +22,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
 
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 
@@ -34,18 +34,18 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIA
  * Configuration to inject a NonannotatedVariants bean that reads from a mongo database in the pipeline
  */
 @Configuration
-@Import({ MongoDBHelper.class })
+@Import({ MongoConfiguration.class })
 public class NonAnnotatedVariantsMongoReaderConfiguration {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Bean(NON_ANNOTATED_VARIANTS_READER)
     @StepScope
     public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(JobOptions jobOptions)
             throws UnknownHostException {
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                           jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
         return new NonAnnotatedVariantsMongoReader(mongoOperations, jobOptions.getDbCollectionsVariantsName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -22,27 +22,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
+
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.GeneWriter;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENE_WRITER;
 
 @Configuration
-@Import({ MongoDBHelper.class })
+@Import({ MongoConfiguration.class })
 public class GeneWriterConfiguration {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Bean(GENE_WRITER)
     @StepScope
     public ItemWriter<FeatureCoordinates> geneWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                           jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
         return new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ public class GeneWriterConfiguration {
     @Bean(GENE_WRITER)
     @StepScope
     public ItemWriter<FeatureCoordinates> geneWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = MongoDBHelper
-                .getMongoOperations(jobOptions.getDbName(), jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
+                                                                                 jobOptions.getMongoConnection());
         return new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -17,6 +17,7 @@ package uk.ac.ebi.eva.pipeline.configuration.writers;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -32,11 +33,14 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENE_WRITER;
 @Configuration
 public class GeneWriterConfiguration {
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Bean(GENE_WRITER)
     @StepScope
     public ItemWriter<FeatureCoordinates> geneWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
-                                                                                 jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                           jobOptions.getMongoConnection());
         return new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
 import uk.ac.ebi.eva.pipeline.io.writers.GeneWriter;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
@@ -31,6 +32,7 @@ import java.net.UnknownHostException;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENE_WRITER;
 
 @Configuration
+@Import({ MongoDBHelper.class })
 public class GeneWriterConfiguration {
 
     @Autowired

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -25,28 +25,28 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
 import uk.ac.ebi.eva.pipeline.Application;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.VepAnnotationMongoWriter;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_WRITER;
 
 @Configuration
-@Import({ MongoDBHelper.class })
+@Import({ MongoConfiguration.class })
 public class VariantAnnotationWriterConfiguration {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Bean(VARIANT_ANNOTATION_WRITER)
     @StepScope
     @Profile(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
     public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                           jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
         String collections = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         return new VepAnnotationMongoWriter(mongoOperations, collections);
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package uk.ac.ebi.eva.pipeline.configuration.writers;
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -35,12 +36,15 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_
 @Configuration
 public class VariantAnnotationWriterConfiguration {
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Bean(VARIANT_ANNOTATION_WRITER)
     @StepScope
     @Profile(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
     public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
-                                                                                 jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                           jobOptions.getMongoConnection());
         String collections = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         return new VepAnnotationMongoWriter(mongoOperations, collections);
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -39,8 +39,8 @@ public class VariantAnnotationWriterConfiguration {
     @StepScope
     @Profile(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
     public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(JobOptions jobOptions) throws UnknownHostException {
-        MongoOperations mongoOperations = MongoDBHelper.getMongoOperations(jobOptions
-                .getDbName(), jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
+                                                                                 jobOptions.getMongoConnection());
         String collections = jobOptions.getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         return new VepAnnotationMongoWriter(mongoOperations, collections);
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
 import uk.ac.ebi.eva.pipeline.Application;
@@ -34,6 +35,7 @@ import java.net.UnknownHostException;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_WRITER;
 
 @Configuration
+@Import({ MongoDBHelper.class })
 public class VariantAnnotationWriterConfiguration {
 
     @Autowired

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -38,8 +38,8 @@ public class VariantWriterConfiguration {
     @StepScope
     @Profile(Application.VARIANT_WRITER_MONGO_PROFILE)
     public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions) throws Exception {
-        MongoOperations mongoOperations = MongoDBHelper
-                .getMongoOperations(jobOptions.getDbName(), jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
+                                                                                 jobOptions.getMongoConnection());
 
         return new VariantMongoWriter(jobOptions.getDbCollectionsVariantsName(),
                 mongoOperations,

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -29,24 +29,24 @@ import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.commons.models.data.Variant;
 import uk.ac.ebi.eva.pipeline.Application;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.VariantMongoWriter;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 @Configuration
-@Import({ MongoDBHelper.class })
+@Import({ MongoConfiguration.class })
 public class VariantWriterConfiguration {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Bean(VARIANT_WRITER)
     @StepScope
     @Profile(Application.VARIANT_WRITER_MONGO_PROFILE)
     public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions) throws Exception {
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                           jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
 
         return new VariantMongoWriter(jobOptions.getDbCollectionsVariantsName(),
                 mongoOperations,

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,18 @@
  */
 package uk.ac.ebi.eva.pipeline.configuration.writers;
 
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_WRITER;
+
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
+
 import uk.ac.ebi.eva.commons.models.data.Variant;
 import uk.ac.ebi.eva.pipeline.Application;
 import uk.ac.ebi.eva.pipeline.io.writers.VariantMongoWriter;
@@ -29,17 +34,19 @@ import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConver
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
-import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_WRITER;
-
 @Configuration
+@Import({ MongoDBHelper.class })
 public class VariantWriterConfiguration {
+
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
 
     @Bean(VARIANT_WRITER)
     @StepScope
     @Profile(Application.VARIANT_WRITER_MONGO_PROFILE)
     public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions) throws Exception {
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
-                                                                                 jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                           jobOptions.getMongoConnection());
 
         return new VariantMongoWriter(jobOptions.getDbCollectionsVariantsName(),
                 mongoOperations,

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/MongoDbCursorItemReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/MongoDbCursorItemReader.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2012 the original author or authors.
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,42 +14,109 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.ac.ebi.eva.pipeline.io.readers;
 
-import com.mongodb.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
+import java.util.Map;
+
+
 /**
- * @see <a href="https://github.com/acogoluegnes/Spring-Batch-MongoDB/blob/master/src/main/java/com/zenika/batch/item/database/mongo/MongoDbCursorItemReader.java</a>
+ * Mongo item reader that is based on cursors, instead of the pagination used in the default Spring Data MongoDB
+ * reader.
  * <p>
- * Mongo item reader cursor based
+ * Its implementation is based on the one available in
+ * <a href="https://github.com/acogoluegnes/Spring-Batch-MongoDB/blob/master/src/main/java/com/zenika/batch/item/database/mongo/MongoDbCursorItemReader.java</a>
+ * but replaces the direct access to Mongo with a {@link MongoOperations}, following the Spring Data MongoDB model.
  */
-public class MongoDbCursorItemReader extends AbstractItemCountingItemStreamItemReader<DBObject> implements InitializingBean {
+public class MongoDbCursorItemReader extends AbstractItemCountingItemStreamItemReader<DBObject>
+        implements InitializingBean {
 
-    private Mongo mongo;
-
-    private String databaseName;
-
+    private MongoOperations template;
     private String collectionName;
 
-    private DBCursor cursor;
-
+    private DBObject query;
+    private DBObject sort;
     private String[] fields;
 
-    private DBObject refDbObject;
+    private DBCursor cursor;
 
     public MongoDbCursorItemReader() {
         super();
         setName(ClassUtils.getShortName(MongoDbCursorItemReader.class));
     }
 
+    /**
+     * Used to perform operations against the MongoDB instance. Also handles the
+     * mapping of documents to objects.
+     *
+     * @param template The MongoOperations instance to use
+     * @see MongoOperations
+     */
+    public void setTemplate(MongoOperations template) {
+        this.template = template;
+    }
+
+    /**
+     * A DBObject representing the MongoDB query.
+     *
+     * @param query Mongo query to run
+     */
+    public void setQuery(DBObject query) {
+        if (query == null) {
+            query = new BasicDBObject();
+        } else {
+            this.query = query;
+        }
+    }
+
+    /**
+     * List of fields to be returned from the matching documents by MongoDB.
+     *
+     * @param fields List of fields to return.
+     */
+    public void setFields(String... fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * {@link Map} of property names/
+     * {@link org.springframework.data.domain.Sort.Direction} values to sort the
+     * input by.
+     *
+     * @param sorts Map of properties and direction to sort each.
+     */
+    public void setSort(Map<String, Sort.Direction> sorts) {
+        this.sort = convertToSort(sorts);
+    }
+
+    /**
+     * Name of the Mongo collection to be queried.
+     *
+     * @param collection Name of the collection
+     */
+    public void setCollection(String collection) {
+        this.collectionName = collection;
+    }
+
     @Override
     protected void doOpen() throws Exception {
-        DBCollection collection = mongo.getDB(databaseName).getCollection(collectionName);
-        cursor = collection.find(createDbObjectRef(), createDbObjectKeys());
+        DBCollection collection = template.getCollection(collectionName);
+        cursor = collection.find(query, createDbObjectKeys());
+        if (sort != null) {
+            cursor = cursor.sort(sort);
+        }
     }
 
     @Override
@@ -65,9 +133,16 @@ public class MongoDbCursorItemReader extends AbstractItemCountingItemStreamItemR
         cursor.close();
     }
 
+    /**
+     * Checks mandatory properties
+     *
+     * @see InitializingBean#afterPropertiesSet()
+     */
     @Override
-    protected void jumpToItem(int itemIndex) throws Exception {
-        cursor = cursor.skip(itemIndex);
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(template, "An implementation of MongoOperations is required.");
+        Assert.notNull(collectionName, "collectionName must be set");
+        Assert.notNull(query, "A query is required.");
     }
 
     private DBObject createDbObjectKeys() {
@@ -82,39 +157,13 @@ public class MongoDbCursorItemReader extends AbstractItemCountingItemStreamItemR
         }
     }
 
-    private DBObject createDbObjectRef() {
-        if (refDbObject == null) {
-            return new BasicDBObject();
-        } else {
-            return refDbObject;
+    private DBObject convertToSort(Map<String, Sort.Direction> sorts) {
+        BasicDBObject sort = new BasicDBObject();
+
+        for (Map.Entry<String, Sort.Direction> currSort : sorts.entrySet()) {
+            sort.append(currSort.getKey(), currSort.getValue());
         }
-    }
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        Assert.notNull(mongo, "Mongo must be specified");
-        Assert.notNull(databaseName, "Mongo AND database must be set");
-        Assert.notNull(collectionName, "collectionName must be set");
+        return sort;
     }
-
-    public void setRefDbObject(DBObject refDbObject) {
-        this.refDbObject = refDbObject;
-    }
-
-    public void setMongo(Mongo mongo) {
-        this.mongo = mongo;
-    }
-
-    public void setFields(String[] fields) {
-        this.fields = fields;
-    }
-
-    public void setDatabaseName(String databaseName) {
-        this.databaseName = databaseName;
-    }
-
-    public void setCollectionName(String collectionName) {
-        this.collectionName = collectionName;
-    }
-
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -36,7 +36,7 @@ public class NonAnnotatedVariantsMongoReader extends MongoDbCursorItemReader {
                                            MongoConnection connection) throws UnknownHostException {
         super();
 
-        setMongo(MongoDBHelper.getMongoClient(connection));
+        setMongo(new MongoDBHelper().getMongoClient(connection));
 
         setDatabaseName(databaseName);
         setCollectionName(collectionsVariantsName);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,33 +18,32 @@ package uk.ac.ebi.eva.pipeline.io.readers;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
-import uk.ac.ebi.eva.utils.MongoConnection;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import javax.annotation.PostConstruct;
+
+import org.springframework.data.mongodb.core.MongoOperations;
 
 import java.net.UnknownHostException;
 
 /**
- * Mongo variant reader using an ItemReader cursor based. This is speeding up the reading of the variant in big
- * collections. The {@link org.springframework.batch.item.data.MongoItemReader} is using pagination and it is slow with
- * large collections
+ * Mongo variant reader using an ItemReader cursor based. This is speeding up
+ * the reading of the variant in big collections. The
+ * {@link org.springframework.batch.item.data.MongoItemReader} is using
+ * pagination and it is slow with large collections
  */
 public class NonAnnotatedVariantsMongoReader extends MongoDbCursorItemReader {
 
-    public NonAnnotatedVariantsMongoReader(String databaseName, String collectionsVariantsName,
-                                           MongoConnection connection) throws UnknownHostException {
+    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName)
+            throws UnknownHostException {
         super();
 
-        setMongo(new MongoDBHelper().getMongoClient(connection));
+        setTemplate(template);
+        setCollection(collectionsVariantsName);
 
-        setDatabaseName(databaseName);
-        setCollectionName(collectionsVariantsName);
+        DBObject query = BasicDBObjectBuilder.start().add("annot.ct.so", new BasicDBObject("$exists", false)).get();
+        setQuery(query);
 
-        DBObject refDbObject = BasicDBObjectBuilder.start().add("annot.ct.so", new BasicDBObject("$exists", false)).get();
-        setRefDbObject(refDbObject);
-
-        String[] fields = {"chr", "start", "end", "ref", "alt"};
+        String[] fields = { "chr", "start", "end", "ref", "alt" };
         setFields(fields);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriter.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriter.java
@@ -19,14 +19,14 @@ package uk.ac.ebi.eva.pipeline.io.writers;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 
-import uk.ac.ebi.eva.utils.MongoDBHelper;
-
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantAnnotationConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.data.MongoItemWriter;
 import org.springframework.data.mongodb.core.MongoOperations;
+
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriter.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriter.java
@@ -18,13 +18,15 @@ package uk.ac.ebi.eva.pipeline.io.writers;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+
+import uk.ac.ebi.eva.utils.MongoDBHelper;
+
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantAnnotationConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.data.MongoItemWriter;
 import org.springframework.data.mongodb.core.MongoOperations;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
@@ -25,9 +25,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.FileLoaderStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 import uk.ac.ebi.eva.utils.TaskletUtils;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_FILE_STEP;
@@ -37,7 +37,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_FILE_STEP;
  */
 @Configuration
 @EnableBatchProcessing
-@Import({ MongoDBHelper.class })
+@Import({ MongoConfiguration.class })
 public class LoadFileStep {
 
     private static final Logger logger = LoggerFactory.getLogger(LoadFileStep.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,11 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.FileLoaderStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 import uk.ac.ebi.eva.utils.TaskletUtils;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_FILE_STEP;
@@ -35,6 +37,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_FILE_STEP;
  */
 @Configuration
 @EnableBatchProcessing
+@Import({ MongoDBHelper.class })
 public class LoadFileStep {
 
     private static final Logger logger = LoggerFactory.getLogger(LoadFileStep.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
@@ -26,11 +26,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.VcfHeaderReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VariantSourceEntityMongoWriter;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.io.File;
 import java.util.Collections;
@@ -46,7 +46,7 @@ import java.util.Collections;
 public class FileLoaderStep implements Tasklet {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Autowired
     private JobOptions jobOptions;
@@ -62,8 +62,8 @@ public class FileLoaderStep implements Tasklet {
         VcfHeaderReader vcfHeaderReader = new VcfHeaderReader(file, variantSource);
         VariantSourceEntity variantSourceEntity = vcfHeaderReader.read();
 
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                           jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
         VariantSourceEntityMongoWriter variantSourceEntityMongoWriter = new VariantSourceEntityMongoWriter(
                 mongoOperations, jobOptions.getDbCollectionsFilesName());
         variantSourceEntityMongoWriter.write(Collections.singletonList(variantSourceEntity));

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
@@ -46,6 +46,9 @@ import java.util.Collections;
 public class FileLoaderStep implements Tasklet {
 
     @Autowired
+    private MongoDBHelper mongoDbHelper;
+
+    @Autowired
     private JobOptions jobOptions;
 
     @Override
@@ -59,8 +62,8 @@ public class FileLoaderStep implements Tasklet {
         VcfHeaderReader vcfHeaderReader = new VcfHeaderReader(file, variantSource);
         VariantSourceEntity variantSourceEntity = vcfHeaderReader.read();
 
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
-                                                                                 jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                           jobOptions.getMongoConnection());
         VariantSourceEntityMongoWriter variantSourceEntityMongoWriter = new VariantSourceEntityMongoWriter(
                 mongoOperations, jobOptions.getDbCollectionsFilesName());
         variantSourceEntityMongoWriter.write(Collections.singletonList(variantSourceEntity));

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,12 @@ package uk.ac.ebi.eva.pipeline.jobs.steps.tasklets;
 import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.datastore.core.ObjectMap;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.stereotype.Component;
 
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
 import uk.ac.ebi.eva.pipeline.io.readers.VcfHeaderReader;
@@ -50,8 +45,6 @@ import java.util.Collections;
  */
 public class FileLoaderStep implements Tasklet {
 
-    private static final Logger logger = LoggerFactory.getLogger(FileLoaderStep.class);
-
     @Autowired
     private JobOptions jobOptions;
 
@@ -66,8 +59,8 @@ public class FileLoaderStep implements Tasklet {
         VcfHeaderReader vcfHeaderReader = new VcfHeaderReader(file, variantSource);
         VariantSourceEntity variantSourceEntity = vcfHeaderReader.read();
 
-        MongoOperations mongoOperations = MongoDBHelper.getMongoOperations(
-                jobOptions.getDbName(), jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
+                                                                                 jobOptions.getMongoConnection());
         VariantSourceEntityMongoWriter variantSourceEntityMongoWriter = new VariantSourceEntityMongoWriter(
                 mongoOperations, jobOptions.getDbCollectionsFilesName());
         variantSourceEntityMongoWriter.write(Collections.singletonList(variantSourceEntity));

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
@@ -33,12 +33,15 @@ import uk.ac.ebi.eva.utils.MongoDBHelper;
 public class IndexesGeneratorStep implements Tasklet {
 
     @Autowired
+    private MongoDBHelper mongoDbHelper;
+
+    @Autowired
     private JobOptions jobOptions;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        MongoOperations operations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
-                                                                            jobOptions.getMongoConnection());
+        MongoOperations operations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
+                                                                      jobOptions.getMongoConnection());
         operations.getCollection(jobOptions.getDbCollectionsFeaturesName())
                 .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
@@ -22,8 +22,9 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 /**
  * This step initializes the indexes in the databases.
@@ -33,15 +34,15 @@ import uk.ac.ebi.eva.utils.MongoDBHelper;
 public class IndexesGeneratorStep implements Tasklet {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Autowired
     private JobOptions jobOptions;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        MongoOperations operations = mongoDbHelper.getMongoOperations(jobOptions.getDbName(),
-                                                                      jobOptions.getMongoConnection());
+        MongoOperations operations = mongoConfiguration.getMongoOperations(
+                jobOptions.getDbName(), jobOptions.getMongoConnection());
         operations.getCollection(jobOptions.getDbCollectionsFeaturesName())
                 .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 package uk.ac.ebi.eva.pipeline.jobs.steps.tasklets;
 
 import com.mongodb.BasicDBObject;
-import org.opencb.datastore.core.ObjectMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
@@ -34,16 +31,14 @@ import uk.ac.ebi.eva.utils.MongoDBHelper;
  * Currently it only has indexes for the features collection.
  */
 public class IndexesGeneratorStep implements Tasklet {
-    private static final Logger logger = LoggerFactory.getLogger(IndexesGeneratorStep.class);
 
     @Autowired
     private JobOptions jobOptions;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-        MongoOperations operations = MongoDBHelper.getMongoOperations(jobOptions.getDbName(),
-                jobOptions.getMongoConnection());
+        MongoOperations operations = new MongoDBHelper().getMongoOperations(jobOptions.getDbName(),
+                                                                            jobOptions.getMongoConnection());
         operations.getCollection(jobOptions.getDbCollectionsFeaturesName())
                 .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsLoaderStep.java
@@ -39,6 +39,7 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.utils.MongoDBHelper;

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoConnection.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoConnection.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.eva.utils;
 
+import com.mongodb.ReadPreference;
+
 public class MongoConnection {
 
     private final String hosts;
@@ -10,7 +12,7 @@ public class MongoConnection {
 
     private final String password;
 
-    private final String readPreference;
+    private final ReadPreference readPreference;
 
     public MongoConnection(String hosts, String authenticationDatabase, String user, String password,
             String readPreference) {
@@ -18,7 +20,7 @@ public class MongoConnection {
         this.authenticationDatabase = authenticationDatabase;
         this.user = user;
         this.password = password;
-        this.readPreference = readPreference;
+        this.readPreference = ReadPreference.valueOf(readPreference);
     }
 
     public String getHosts() {
@@ -37,8 +39,11 @@ public class MongoConnection {
         return password;
     }
 
-    public String getReadPreference() {
+    public ReadPreference getReadPreference() {
         return readPreference;
     }
 
+    public String getReadPreferenceName() {
+        return readPreference.getName();
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -15,9 +15,7 @@
  */
 package uk.ac.ebi.eva.utils;
 
-import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
-
 import org.opencb.commons.utils.CryptoUtils;
 
 import uk.ac.ebi.eva.commons.models.data.Variant;
@@ -45,20 +43,6 @@ public class MongoDBHelper {
             }
         }
         return serverAddresses;
-    }
-
-    public static ReadPreference getMongoTemplateReadPreferences(String readPreference) {
-        switch (readPreference) {
-            case "primary":
-                return ReadPreference.primary();
-            case "secondary":
-                return ReadPreference.secondary();
-            default:
-                throw new IllegalArgumentException(
-                        String.format("%s is not a valid ReadPreference type, please use \"primary\" or \"secondary\"",
-                                readPreference));
-        }
-
     }
 
     public static String buildStorageId(Variant v) {

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *          http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,109 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package uk.ac.ebi.eva.utils;
 
-import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
-import org.opencb.commons.utils.CryptoUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDbFactory;
-import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
-import org.springframework.data.mongodb.core.convert.DbRefResolver;
-import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
-import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
-import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
-
-import com.mongodb.MongoClient;
-import com.mongodb.MongoCredential;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 
+import org.opencb.commons.utils.CryptoUtils;
+
 import uk.ac.ebi.eva.commons.models.data.Variant;
 
-/**
- * Utility class dealing with MongoDB connections using pipeline options
- */
-@Configuration
+import java.net.UnknownHostException;
+import java.util.LinkedList;
+import java.util.List;
+
+
 public class MongoDBHelper {
-
-    @Autowired
-    private MongoMappingContext mongoMappingContext;
-
-    @Bean
-    public MongoMappingContext mongoMappingContext() {
-        return new MongoMappingContext();
-    }
-
-    public MongoOperations getDefaultMongoOperations(String database) throws UnknownHostException {
-        MongoClient mongoClient = new MongoClient();
-        mongoClient.setReadPreference(ReadPreference.primary());
-        MongoDbFactory mongoFactory = getMongoDbFactory(mongoClient, database);
-        MongoTemplate mongoTemplate = new MongoTemplate(mongoFactory, getMappingMongoConverter(mongoFactory));
-        return mongoTemplate;
-    }
-
-    public MongoOperations getMongoOperations(String database, MongoConnection connection) 
-            throws UnknownHostException {
-        MongoClient mongoClient = getMongoClient(connection);
-        MongoDbFactory mongoFactory = getMongoDbFactory(mongoClient, database);
-        MongoTemplate mongoTemplate = new MongoTemplate(mongoFactory, getMappingMongoConverter(mongoFactory));
-        return mongoTemplate;
-    }
     
-    public MongoClient getMongoClient(MongoConnection connection) throws UnknownHostException {
-        String authenticationDatabase = null;
-        String user = null;
-        String password = null;
-        MongoClient mongoClient;
-        
-        // The Mongo API is not happy to deal with empty strings for authentication DB, user and password
-        if (connection.getAuthenticationDatabase() != null && !connection.getAuthenticationDatabase().trim().isEmpty()) {
-            authenticationDatabase = connection.getAuthenticationDatabase();
-        }
-        if (connection.getUser() != null && !connection.getUser().trim().isEmpty()) {
-            user = connection.getUser();
-        }
-        if (connection.getPassword() != null && !connection.getPassword().trim().isEmpty()) {
-            password = connection.getPassword();
-        }
-        
-        if (user == null || password == null) {
-            mongoClient = new MongoClient(parseServerAddresses(connection.getHosts()));
-        } else {
-            mongoClient = new MongoClient(
-                    parseServerAddresses(connection.getHosts()),
-                    Collections.singletonList(MongoCredential.createCredential(connection.getUser(),
-                            authenticationDatabase, connection.getPassword().toCharArray())));
-        }
-        mongoClient.setReadPreference(getMongoTemplateReadPreferences(connection.getReadPreference()));
-
-        return mongoClient;
+    private MongoDBHelper() {
+        // Can't be instantiated
     }
 
-    private MongoDbFactory getMongoDbFactory(MongoClient client, String database) {
-        return new SimpleMongoDbFactory(client, database);
-    }
-
-    private MappingMongoConverter getMappingMongoConverter(MongoDbFactory mongoFactory) {
-        DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoFactory);
-        MappingMongoConverter mongoConverter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
-
-        // Customization: replace dots with pound sign
-        mongoConverter.setMapKeyDotReplacement("£");
-
-        return mongoConverter;
-    }
-
-    private List<ServerAddress> parseServerAddresses(String hosts) throws UnknownHostException {
+    public static List<ServerAddress> parseServerAddresses(String hosts) throws UnknownHostException {
         List<ServerAddress> serverAddresses = new LinkedList<>();
         for (String hostPort : hosts.split(",")) {
             if (hostPort.contains(":")) {
@@ -129,8 +47,7 @@ public class MongoDBHelper {
         return serverAddresses;
     }
 
-
-    private ReadPreference getMongoTemplateReadPreferences(String readPreference) {
+    public static ReadPreference getMongoTemplateReadPreferences(String readPreference) {
         switch (readPreference) {
             case "primary":
                 return ReadPreference.primary();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/ApplicationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/ApplicationTest.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.eva.pipeline;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,12 +14,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
-import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-
-import java.util.List;
 
 /**
  * The purpose of this test is to imitate an execution made by an user through the CLI.

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -29,12 +29,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.readers.NonAnnotatedVariantsMongoReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.io.IOException;
 
@@ -64,7 +64,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
     private JobOptions jobOptions;
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Before
     public void setUp() throws Exception {
@@ -76,7 +76,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
         ExecutionContext executionContext = MetaDataInstanceFactory.createStepExecution().getExecutionContext();
         String databaseName = insertDocuments(jobOptions.getDbCollectionsVariantsName());
 
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName,
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
 
         NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -27,9 +27,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.ac.ebi.eva.pipeline.jobs.AnnotationJob;
+
+import uk.ac.ebi.eva.pipeline.configuration.readers.NonAnnotatedVariantsMongoReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
+import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringRunner.class)
 @ActiveProfiles("variant-annotation-mongo")
 @TestPropertySource("classpath:annotation.properties")
-@ContextConfiguration(classes = {AnnotationJob.class, BatchTestConfiguration.class})
+@ContextConfiguration(classes = {NonAnnotatedVariantsMongoReaderConfiguration.class, BaseTestConfiguration.class})
 public class NonAnnotatedVariantsMongoReaderTest {
 
     private static final String DOC_CHR = "chr";

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -33,6 +34,7 @@ import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.io.IOException;
 
@@ -61,6 +63,9 @@ public class NonAnnotatedVariantsMongoReaderTest {
     @Autowired
     private JobOptions jobOptions;
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Before
     public void setUp() throws Exception {
         jobOptions.loadArgs();
@@ -71,8 +76,11 @@ public class NonAnnotatedVariantsMongoReaderTest {
         ExecutionContext executionContext = MetaDataInstanceFactory.createStepExecution().getExecutionContext();
         String databaseName = insertDocuments(jobOptions.getDbCollectionsVariantsName());
 
-        NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(databaseName,
-                jobOptions.getDbCollectionsVariantsName(), jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName,
+                jobOptions.getMongoConnection());
+
+        NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
+                mongoOperations, jobOptions.getDbCollectionsVariantsName());
         mongoItemReader.open(executionContext);
 
         int itemCount = 0;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -33,13 +33,13 @@ import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.GtfStaticTestData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static uk.ac.ebi.eva.utils.MongoDBHelper.getMongoOperations;
 
 /**
  * {@link GeneWriter}
@@ -61,7 +61,7 @@ public class GeneWriterTest {
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
 
-        MongoOperations mongoOperations = getMongoOperations(databaseName,
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
 
         GeneWriter geneWriter = new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.GeneWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
@@ -35,7 +36,6 @@ import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.GtfStaticTestData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,13 +60,13 @@ public class GeneWriterTest {
     private JobOptions jobOptions;
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
 
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName,
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
 
         GeneWriter geneWriter = new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -27,6 +27,8 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.pipeline.configuration.writers.GeneWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
@@ -48,7 +50,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:initialize-database.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class, GeneWriterConfiguration.class})
 public class GeneWriterTest {
 
     @Rule

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -57,11 +57,14 @@ public class GeneWriterTest {
     @Autowired
     private JobOptions jobOptions;
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
 
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
+        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
 
         GeneWriter geneWriter = new GeneWriter(mongoOperations, jobOptions.getDbCollectionsFeaturesName());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,9 @@ import static org.junit.Assert.assertNotNull;
 @TestPropertySource({"classpath:common-configuration.properties"})
 @ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class StatisticsMongoWriterTest {
+
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -162,10 +165,9 @@ public class StatisticsMongoWriterTest {
     }
 
     public StatisticsMongoWriter getStatisticsMongoWriter(String databaseName) throws UnknownHostException {
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
-                jobOptions.getMongoConnection());
+        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
         StatisticsMongoWriter statisticsMongoWriter = new StatisticsMongoWriter(
-                mongoOperations, jobOptions.getDbCollectionsStatsName());
+                operations, jobOptions.getDbCollectionsStatsName());
         return statisticsMongoWriter;
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -50,10 +50,12 @@ import static org.junit.Assert.assertNotNull;
  * {@link StatisticsMongoWriter}
  * input: a List of {@link PopulationStatistics} to each call of `.write()`
  * output: the FeatureCoordinates get written in mongo, with at least: chromosome, start and end.
+ *
+ * TODO Replace MongoDBHelper with StatisticsMongoWriterConfiguration in ContextConfiguration when the class exists
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:common-configuration.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class, MongoDBHelper.class})
 public class StatisticsMongoWriterTest {
 
     @Autowired

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -162,7 +162,7 @@ public class StatisticsMongoWriterTest {
     }
 
     public StatisticsMongoWriter getStatisticsMongoWriter(String databaseName) throws UnknownHostException {
-        MongoOperations mongoOperations = MongoDBHelper.getMongoOperations(databaseName,
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
         StatisticsMongoWriter statisticsMongoWriter = new StatisticsMongoWriter(
                 mongoOperations, jobOptions.getDbCollectionsStatsName());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -29,12 +29,13 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.model.PopulationStatistics;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -55,11 +56,11 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:common-configuration.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class, MongoDBHelper.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class, MongoConfiguration.class})
 public class StatisticsMongoWriterTest {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -167,7 +168,8 @@ public class StatisticsMongoWriterTest {
     }
 
     public StatisticsMongoWriter getStatisticsMongoWriter(String databaseName) throws UnknownHostException {
-        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        MongoOperations operations = mongoConfiguration.getMongoOperations(
+                databaseName, jobOptions.getMongoConnection());
         StatisticsMongoWriter statisticsMongoWriter = new StatisticsMongoWriter(
                 operations, jobOptions.getDbCollectionsStatsName());
         return statisticsMongoWriter;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.pipeline.configuration.writers.VariantWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
@@ -53,7 +54,7 @@ import static org.mockito.Mockito.when;
  * Testing {@link VariantMongoWriter}
  */
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = { MongoDBHelper.class })
+@ContextConfiguration(classes = { VariantWriterConfiguration.class })
 public class VariantMongoWriterTest {
 
     @Autowired

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -65,7 +65,7 @@ public class VariantMongoWriterTest {
     @Test
     public void noVariantsNothingShouldBeWritten() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = MongoDBHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = new MongoDBHelper().getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations, variantToMongoDbObjectConverter);
@@ -80,7 +80,7 @@ public class VariantMongoWriterTest {
         Variant variant2 = new Variant("2", 3, 4, "C", "G");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = MongoDBHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = new MongoDBHelper().getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         BasicDBObject dbObject = new BasicDBObject();
@@ -97,7 +97,7 @@ public class VariantMongoWriterTest {
     @Test
     public void indexesShouldBeCreatedInBackground() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = MongoDBHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = new MongoDBHelper().getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations, variantToMongoDbObjectConverter);
@@ -120,7 +120,7 @@ public class VariantMongoWriterTest {
         Variant variant1 = new Variant("1", 1, 2, "A", "T");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = MongoDBHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = new MongoDBHelper().getDefaultMongoOperations(dbName);
 
         BasicDBObject dbObject = new BasicDBObject();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -30,10 +30,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VariantWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.when;
 public class VariantMongoWriterTest {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     private static final List<? extends Variant> EMPTY_LIST = new ArrayList<>();
 
@@ -73,7 +73,7 @@ public class VariantMongoWriterTest {
     @Test
     public void noVariantsNothingShouldBeWritten() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = mongoConfiguration.getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -89,7 +89,7 @@ public class VariantMongoWriterTest {
         Variant variant2 = new Variant("2", 3, 4, "C", "G");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = mongoConfiguration.getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         BasicDBObject dbObject = new BasicDBObject();
@@ -107,7 +107,7 @@ public class VariantMongoWriterTest {
     @Test
     public void indexesShouldBeCreatedInBackground() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = mongoConfiguration.getDefaultMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -131,7 +131,7 @@ public class VariantMongoWriterTest {
         Variant variant1 = new Variant("1", 1, 2, "A", "T");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getDefaultMongoOperations(dbName);
+        MongoOperations mongoOperations = mongoConfiguration.getDefaultMongoOperations(dbName);
 
         BasicDBObject dbObject = new BasicDBObject();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -32,13 +32,13 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.VcfHeaderReader;
 import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.io.File;
 import java.util.Arrays;
@@ -72,14 +72,15 @@ public class VariantSourceEntityMongoWriterTest {
     private JobOptions jobOptions;
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     private String input;
 
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                databaseName, jobOptions.getMongoConnection());
         DBCollection fileCollection = mongoRule.getCollection(databaseName, jobOptions.getDbCollectionsFilesName());
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(
@@ -118,7 +119,8 @@ public class VariantSourceEntityMongoWriterTest {
     @Test
     public void shouldWriteSamplesWithDotsInName() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
+                databaseName, jobOptions.getMongoConnection());
         DBCollection fileCollection = mongoRule.getCollection(databaseName, jobOptions.getDbCollectionsFilesName());
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -15,18 +15,9 @@
  */
 package uk.ac.ebi.eva.pipeline.io.writers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResource;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,17 +31,26 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
 import uk.ac.ebi.eva.pipeline.io.readers.VcfHeaderReader;
+import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResource;
 
 /**
  * {@link VariantSourceEntityMongoWriter}
@@ -60,8 +60,10 @@ import uk.ac.ebi.eva.utils.MongoDBHelper;
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:genotyped-vcf.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class, LoadFileStep.class})
 public class VariantSourceEntityMongoWriterTest {
+
+    private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -160,7 +162,7 @@ public class VariantSourceEntityMongoWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        input = getResource(jobOptions.getPipelineOptions().getString(JobParametersNames.INPUT_VCF)).getAbsolutePath();
+        input = getResource(SMALL_VCF_FILE).getAbsolutePath();
         jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, input);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -35,7 +35,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
-import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.utils.MongoDBHelper;
 
@@ -88,7 +87,7 @@ public class VepAnnotationMongoWriterTest {
         writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
-        MongoOperations mongoOperations = MongoDBHelper.getMongoOperations(databaseName,
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
         annotationWriter = new VepAnnotationMongoWriter(mongoOperations, dbCollectionVariantsName);
         annotationWriter.write(annotations);
@@ -147,7 +146,7 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        MongoOperations mongoOperations = MongoDBHelper.getMongoOperations(databaseName,
+        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
                 jobOptions.getMongoConnection());
         annotationWriter = new VepAnnotationMongoWriter(mongoOperations, dbCollectionVariantsName);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VariantAnnotationWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
@@ -63,7 +64,7 @@ import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 public class VepAnnotationMongoWriterTest {
 
     @Autowired
-    private MongoDBHelper mongoDbHelper;
+    private MongoConfiguration mongoConfiguration;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -91,7 +92,8 @@ public class VepAnnotationMongoWriterTest {
         writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
-        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        MongoOperations operations = mongoConfiguration.getMongoOperations(
+                databaseName, jobOptions.getMongoConnection());
         annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
         annotationWriter.write(annotations);
 
@@ -149,7 +151,8 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        MongoOperations operations = mongoConfiguration.getMongoOperations(
+                databaseName, jobOptions.getMongoConnection());
         annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
 
         annotationWriter.write(annotationSet1);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ebi.eva.pipeline.configuration.writers.VariantAnnotationWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
@@ -58,7 +59,7 @@ import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 @RunWith(SpringRunner.class)
 @ActiveProfiles("variant-annotation-mongo")
 @TestPropertySource("classpath:annotation.properties")
-@ContextConfiguration(classes = {BaseTestConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class, VariantAnnotationWriterConfiguration.class})
 public class VepAnnotationMongoWriterTest {
 
     @Autowired

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,9 @@ import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 @ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class VepAnnotationMongoWriterTest {
 
+    @Autowired
+    private MongoDBHelper mongoDbHelper;
+
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
@@ -87,9 +90,8 @@ public class VepAnnotationMongoWriterTest {
         writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
-                jobOptions.getMongoConnection());
-        annotationWriter = new VepAnnotationMongoWriter(mongoOperations, dbCollectionVariantsName);
+        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
         annotationWriter.write(annotations);
 
         // and finally check that documents in DB have annotation (only consequence type)
@@ -146,9 +148,8 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        MongoOperations mongoOperations = new MongoDBHelper().getMongoOperations(databaseName,
-                jobOptions.getMongoConnection());
-        annotationWriter = new VepAnnotationMongoWriter(mongoOperations, dbCollectionVariantsName);
+        MongoOperations operations = mongoDbHelper.getMongoOperations(databaseName, jobOptions.getMongoConnection());
+        annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
 
         annotationWriter.write(annotationSet1);
         annotationWriter.write(annotationSet2);

--- a/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
@@ -1,14 +1,26 @@
+/*
+ * Copyright 2016-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.test.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 @Configuration
-@Import({ MongoDBHelper.class })
 public class BaseTestConfiguration {
 
     @Bean

--- a/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
@@ -2,9 +2,13 @@ package uk.ac.ebi.eva.test.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 @Configuration
+@Import({ MongoDBHelper.class })
 public class BaseTestConfiguration {
 
     @Bean


### PR DESCRIPTION
When using OpenCGA converters to store `VariantSource` objects, dots in samples names were mapped to another character (this is a Mongo requirement).

This behavior is now replicated using the class `MappingMongoConverter` from Spring Data. In order to provide instances of this class to build `MongoTemplate` objects, `MongoDBHelper` must support being autowired, which involves:

* It must be annotated as `@Configuration`
* Those methods creating `MongoTemplate` objects can't be static anymore
* Reader / writer / tasklet-step configurations need to `@Import({ MongoDBHelper.class })`, to ensure they will work both in tests and stand-alone runs