### PR TITLE
EVA-596 Use JobParameters in statistics generation step

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
@@ -23,6 +23,9 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
@@ -34,6 +37,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.CALCULATE_STATISTIC
  */
 @Configuration
 @EnableBatchProcessing
+@Import({ MongoConfiguration.class })
 public class CalculateStatisticsStep {
 
     private static final Logger logger = LoggerFactory.getLogger(CalculateStatisticsStep.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
@@ -23,9 +23,7 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
@@ -37,7 +35,6 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.CALCULATE_STATISTIC
  */
 @Configuration
 @EnableBatchProcessing
-@Import({ MongoConfiguration.class })
 public class CalculateStatisticsStep {
 
     private static final Logger logger = LoggerFactory.getLogger(CalculateStatisticsStep.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
@@ -23,8 +23,8 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsLoaderStep;
-import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.VepAnnotationGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
@@ -60,10 +60,6 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
     @Autowired
     private DatabaseParameters dbParameters;
 
-    public static String VARIANT_STATS_SUFFIX = ".variants.stats.json.gz";
-
-    public static String SOURCE_STATS_SUFFIX = ".source.stats.json.gz";
-
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
 //                HashMap<String, Set<String>> samples = new HashMap<>(); // TODO fill properly. if this is null overwrite will take on
@@ -83,24 +79,10 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
         return RepeatStatus.FINISHED;
     }
 
-    public static URI getStatsBaseUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
-        URI outdirUri = URLHelper.createUri(outputDirStatistics);
-        return outdirUri.resolve(MongoDBHelper.buildStorageFileId(studyId, fileId));
-    }
-
-    public static URI getVariantsStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
-        return URLHelper.createUri(
-                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + VARIANT_STATS_SUFFIX);
-    }
-
-    public static URI getSourceStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
-        return URLHelper.createUri(
-                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + SOURCE_STATS_SUFFIX);
-    }
-
     private URI getStatsBaseUri() throws URISyntaxException {
         VariantSource source = getVariantSource();
-        return getStatsBaseUri(outputParameters.getOutputDirStatistics(), source.getStudyId(), source.getFileId());
+        return URLHelper.getStatsBaseUri(
+                outputParameters.getOutputDirStatistics(), source.getStudyId(), source.getFileId());
     }
 
     private ObjectMap getVariantOptions() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
@@ -22,22 +22,24 @@ import org.opencb.opencga.storage.core.StorageManagerFactory;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.opencb.opencga.storage.core.variant.adaptors.VariantDBAdaptor;
 import org.opencb.opencga.storage.core.variant.stats.VariantStatisticsManager;
+import org.opencb.opencga.storage.mongodb.variant.MongoDBVariantStorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
-import org.springframework.stereotype.Component;
 
-import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
+import uk.ac.ebi.eva.pipeline.parameters.InputParameters;
+import uk.ac.ebi.eva.pipeline.parameters.OutputParameters;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
 /**
  * Tasklet that calculates statistics. See {@link org.opencb.biodata.models.variant.stats.VariantStats} for a list of
@@ -50,22 +52,27 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
     private static final Logger logger = LoggerFactory.getLogger(PopulationStatisticsGeneratorStep.class);
 
     @Autowired
-    private JobOptions jobOptions;
+    private InputParameters inputParameters;
+
+    @Autowired
+    private OutputParameters outputParameters;
+
+    @Autowired
+    private DatabaseParameters dbParameters;
+
+    public static String VARIANT_STATS_SUFFIX = ".variants.stats.json.gz";
+
+    public static String SOURCE_STATS_SUFFIX = ".source.stats.json.gz";
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        ObjectMap variantOptions = jobOptions.getVariantOptions();
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-
 //                HashMap<String, Set<String>> samples = new HashMap<>(); // TODO fill properly. if this is null overwrite will take on
 //                samples.put("SOME", new HashSet<>(Arrays.asList("HG00096", "HG00097")));
 
+        ObjectMap variantOptions = getVariantOptions();
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();
-        VariantSource variantSource = variantOptions.get(VariantStorageManager.VARIANT_SOURCE, VariantSource.class);
-        VariantDBAdaptor dbAdaptor = variantStorageManager.getDBAdaptor(
-                variantOptions.getString(VariantStorageManager.DB_NAME), variantOptions);
-        URI outdirUri = URLHelper.createUri(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS));
-        URI statsOutputUri = outdirUri.resolve(VariantStorageManager.buildFilename(variantSource));
+        VariantDBAdaptor dbAdaptor = variantStorageManager.getDBAdaptor(dbParameters.getDatabaseName(), variantOptions);
+        URI statsOutputUri = getStatsBaseUri();
 
         VariantStatisticsManager variantStatisticsManager = new VariantStatisticsManager();
         QueryOptions statsOptions = new QueryOptions(variantOptions);
@@ -74,5 +81,67 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
         variantStatisticsManager.createStats(dbAdaptor, statsOutputUri, null, statsOptions);    // TODO allow subset of samples
 
         return RepeatStatus.FINISHED;
+    }
+
+    public static URI getStatsBaseUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        URI outdirUri = URLHelper.createUri(outputDirStatistics);
+        return outdirUri.resolve(MongoDBHelper.buildStorageFileId(studyId, fileId));
+    }
+
+    public static URI getVariantsStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        return URLHelper.createUri(
+                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + VARIANT_STATS_SUFFIX);
+    }
+
+    public static URI getSourceStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        return URLHelper.createUri(
+                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + SOURCE_STATS_SUFFIX);
+    }
+
+    private URI getStatsBaseUri() throws URISyntaxException {
+        VariantSource source = getVariantSource();
+        return getStatsBaseUri(outputParameters.getOutputDirStatistics(), source.getStudyId(), source.getFileId());
+    }
+
+    private ObjectMap getVariantOptions() {
+
+        VariantSource source = getVariantSource();
+
+        // OpenCGA options with default values (non-customizable)
+        String compressExtension = ".gz";
+        boolean annotate = false;
+        VariantStorageManager.IncludeSrc includeSourceLine = VariantStorageManager.IncludeSrc.FIRST_8_COLUMNS;
+
+        ObjectMap variantOptions = new ObjectMap();
+        variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
+        variantOptions.put(VariantStorageManager.OVERWRITE_STATS, outputParameters.getStatisticsOverwrite());
+        variantOptions.put(VariantStorageManager.INCLUDE_SRC, includeSourceLine);
+        variantOptions.put("compressExtension", compressExtension);
+        variantOptions.put(VariantStorageManager.ANNOTATE, annotate);
+        variantOptions.put(VariantStatisticsManager.BATCH_SIZE, inputParameters.getChunkSize());
+
+        variantOptions.put(VariantStorageManager.DB_NAME, dbParameters.getDatabaseName());
+        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME,
+                dbParameters.getDatabaseName());
+        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_HOSTS,
+                dbParameters.getHosts());
+        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_AUTHENTICATION_DB,
+                dbParameters.getAuthenticationDatabase());
+        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_USER,
+                dbParameters.getUser());
+        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_PASS,
+                dbParameters.getPassword());
+
+        return variantOptions;
+    }
+
+    private VariantSource getVariantSource() {
+        return new VariantSource(
+                    Paths.get(inputParameters.getVcf()).getFileName().toString(),
+                    inputParameters.getVcfId(),
+                    inputParameters.getStudyId(),
+                    inputParameters.getStudyName(),
+                    inputParameters.getStudyType(),
+                    inputParameters.getVcfAggregation());
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/PopulationStatisticsGeneratorStep.java
@@ -80,9 +80,8 @@ public class PopulationStatisticsGeneratorStep implements Tasklet {
     }
 
     private URI getStatsBaseUri() throws URISyntaxException {
-        VariantSource source = getVariantSource();
         return URLHelper.getStatsBaseUri(
-                outputParameters.getOutputDirStatistics(), source.getStudyId(), source.getFileId());
+                outputParameters.getOutputDirStatistics(), inputParameters.getStudyId(), inputParameters.getVcfId());
     }
 
     private ObjectMap getVariantOptions() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/DatabaseParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/DatabaseParameters.java
@@ -15,7 +15,7 @@
  */
 package uk.ac.ebi.eva.pipeline.parameters;
 
-import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +26,7 @@ import uk.ac.ebi.eva.utils.MongoConnection;
  * values for database connection that are got as values not parameters.
  */
 @Service
-@JobScope
+@StepScope
 public class DatabaseParameters {
 
     private static final String PARAMETER = "#{jobParameters['";
@@ -70,5 +70,25 @@ public class DatabaseParameters {
 
     public String getCollectionFilesName() {
         return collectionFilesName;
+    }
+
+    public String getHosts() {
+        return hosts;
+    }
+
+    public String getAuthenticationDatabase() {
+        return authenticationDatabase;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getReadPreference() {
+        return readPreference;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/InputParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/InputParameters.java
@@ -17,17 +17,15 @@ package uk.ac.ebi.eva.pipeline.parameters;
 
 import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.biodata.models.variant.VariantStudy;
-import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.nio.file.Paths;
 
 /**
  * Service that holds access to Job input parameters.
  */
 @Service
-@JobScope
+@StepScope
 public class InputParameters {
 
     private static final String PARAMETER = "#{jobParameters['";
@@ -51,6 +49,17 @@ public class InputParameters {
     @Value(PARAMETER + JobParametersNames.INPUT_STUDY_TYPE + END)
     private VariantStudy.StudyType studyType;
 
+    // maybe the next three could go into a ConfigurationParameters?
+
+    @Value(PARAMETER + JobParametersNames.APP_OPENCGA_PATH  + END)
+    private String opencgaAppHome;
+
+    @Value(PARAMETER + JobParametersNames.CONFIG_RESTARTABILITY_ALLOW + "']?:false}")
+    private boolean allowStartIfComplete;
+
+    @Value(PARAMETER + JobParametersNames.CONFIG_CHUNK_SIZE + "']?:1000}")
+    private int chunkSize;
+
     public String getVcf() {
         return vcf;
     }
@@ -73,5 +82,17 @@ public class InputParameters {
 
     public VariantStudy.StudyType getStudyType() {
         return studyType;
+    }
+
+    public String getOpencgaAppHome() {
+        return opencgaAppHome;
+    }
+
+    public boolean isAllowStartIfComplete() {
+        return allowStartIfComplete;
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/OutputParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/OutputParameters.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service that holds access to Job input parameters.
+ */
+@Service
+@StepScope
+public class OutputParameters {
+
+    private static final String PARAMETER = "#{jobParameters['";
+    private static final String END = "']}";
+
+    @Value(PARAMETER + JobParametersNames.OUTPUT_DIR  + END)
+    private String outputDir;
+
+    @Value(PARAMETER + JobParametersNames.OUTPUT_DIR_ANNOTATION + END)
+    private String outputDirAnnotation;
+
+    @Value(PARAMETER + JobParametersNames.OUTPUT_DIR_STATISTICS  + END)
+    private String outputDirStatistics;
+
+    @Value(PARAMETER + JobParametersNames.STATISTICS_OVERWRITE  + "']?:false}")
+    private boolean statisticsOverwrite;
+
+    public String getOutputDir() {
+        return outputDir;
+    }
+
+    public String getOutputDirAnnotation() {
+        return outputDirAnnotation;
+    }
+
+    public String getOutputDirStatistics() {
+        return outputDirStatistics;
+    }
+
+    public boolean getStatisticsOverwrite() {
+        return statisticsOverwrite;
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
@@ -56,6 +56,9 @@ public class ParametersFromProperties {
     @Value(PROPERTY + JobParametersNames.INPUT_VCF_AGGREGATION + OR_NULL)
     private String vcfAggregation;
 
+    @Value(PROPERTY + JobParametersNames.OUTPUT_DIR_STATISTICS + OR_NULL)
+    private String outputDirStats;
+
     public Properties getProperties() {
         Properties properties = new Properties();
 

--- a/src/main/java/uk/ac/ebi/eva/utils/URLHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/URLHelper.java
@@ -21,6 +21,10 @@ import java.nio.file.Paths;
 
 public class URLHelper {
 
+    private static final String VARIANT_STATS_SUFFIX = ".variants.stats.json.gz";
+
+    private static final String SOURCE_STATS_SUFFIX = ".source.stats.json.gz";
+
     public static URI createUri(String input) throws URISyntaxException {
         URI sourceUri = new URI(input);
         if (sourceUri.getScheme() == null || sourceUri.getScheme().isEmpty()) {
@@ -29,4 +33,18 @@ public class URLHelper {
         return sourceUri;
     }
 
+    public static URI getVariantsStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        return URLHelper.createUri(
+                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + VARIANT_STATS_SUFFIX);
+    }
+
+    public static URI getSourceStatsUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        return URLHelper.createUri(
+                getStatsBaseUri(outputDirStatistics, studyId, fileId).getPath() + SOURCE_STATS_SUFFIX);
+    }
+
+    public static URI getStatsBaseUri(String outputDirStatistics, String studyId, String fileId) throws URISyntaxException {
+        URI outdirUri = URLHelper.createUri(outputDirStatistics);
+        return outdirUri.resolve(MongoDBHelper.buildStorageFileId(studyId, fileId));
+    }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -146,6 +146,7 @@ public class GenotypedVcfJobTest {
                 .vepCacheVersion("")
                 .vepNumForks("")
                 .vepPath(getResource(MOCK_VEP).getPath())
+                .addString(JobParametersNames.OUTPUT_DIR_STATISTICS, outputDir)
 
                 .toJobParameters();
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -260,7 +260,9 @@ public class GenotypedVcfJobWorkflowTest {
                 .vepCacheVersion("")
                 .vepNumForks("")
                 .vepPath(getResource(MOCK_VEP).getPath())
-                .timestamp().toJobParameters();
+                .timestamp()
+                .addString(JobParametersNames.OUTPUT_DIR_STATISTICS, outputDir)
+                .toJobParameters();
 
         // transformedVcf file init
         String transformedVcf = outputDir + inputFileResouce + ".variants.json" + compressExtension;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -37,13 +37,13 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
+import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.io.File;
 
@@ -118,9 +118,9 @@ public class PopulationStatisticsJobTest {
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         //and the file containing statistics should exist
-        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, studyId, fileId));
+        File statsFile = new File(URLHelper.getVariantsStatsUri(statsDir, studyId, fileId));
         assertTrue(statsFile.exists());
-        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, studyId, fileId));
+        File sourceStatsFile = new File(URLHelper.getSourceStatsUri(statsDir, studyId, fileId));
         assertTrue(sourceStatsFile.exists());
 
         // The DB docs should have the field "st"

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -30,39 +30,39 @@ import org.opencb.opencga.storage.core.variant.adaptors.VariantDBIterator;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
-import static uk.ac.ebi.eva.test.utils.TestFileUtils.copyResource;
+import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResource;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 
 /**
  * Test for {@link PopulationStatisticsJob}
  */
 @RunWith(SpringRunner.class)
-@TestPropertySource({"classpath:common-configuration.properties"})
+@TestPropertySource({"classpath:common-configuration.properties", "classpath:test-mongo.properties"})
 @ContextConfiguration(classes = {PopulationStatisticsJob.class, BatchTestConfiguration.class})
 public class PopulationStatisticsJobTest {
     private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
+
     private static final String MONGO_DUMP = "/dump/VariantStatsConfigurationTest_vl";
-    private static final String VARIANTS_FILE_NAME = "/1_1.variants.stats.json.gz";
-    private static final String SOURCE_FILE_NAME = "/1_1.source.stats.json.gz";
-    private static final String VCF_FILE_NAME = "/small20.vcf.gz.variants.json.gz";
 
     @Rule
     public PipelineTemporaryFolderRule temporaryFolderRule = new PipelineTemporaryFolderRule();
@@ -82,53 +82,53 @@ public class PopulationStatisticsJobTest {
     public void fullPopulationStatisticsJob() throws Exception {
         //Given a valid VCF input file
         String input = SMALL_VCF_FILE;
+        String statsDir = temporaryFolderRule.getRoot().getPath();
+        String dbName = mongoRule.restoreDumpInTemporaryDatabase(getResourceUrl(MONGO_DUMP));
+        String fileId = "1";
+        String studyId = "1";
 
+        // TODO remove when statisticsLoadStep uses job parameter ↓
         pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
+        pipelineOptions.put(JobParametersNames.OUTPUT_DIR_STATISTICS, statsDir);
+        jobOptions.setDbName(dbName);
 
         VariantSource source = new VariantSource(
                 input,
-                "1",
-                "1",
+                fileId,
+                studyId,
                 "studyName",
                 VariantStudy.StudyType.COLLECTION,
                 VariantSource.Aggregation.NONE);
-
         variantOptions.put(VARIANT_SOURCE, source);
+        // TODO end section to remove when statisticsLoadStep uses job parameter ↑
 
-        initStatsLoadStepFiles();
+        JobParameters jobParameters = new EvaJobParameterBuilder()
+                .inputVcf(getResource(input).getAbsolutePath())
+                .databaseName(dbName)
+                .collectionVariantsName("variants")
+                .inputVcfId(fileId)
+                .inputStudyId(studyId)
+                .inputVcfAggregation("BASIC")
+                .timestamp()
+                .addString(JobParametersNames.OUTPUT_DIR_STATISTICS, statsDir)
+                .toJobParameters();
 
-        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
         assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         //and the file containing statistics should exist
-        File statsFile = new File(Paths.get(pipelineOptions.getString(JobParametersNames.OUTPUT_DIR_STATISTICS))
-                .resolve(VariantStorageManager.buildFilename(source)) + ".variants.stats.json.gz");
+        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, studyId, fileId));
         assertTrue(statsFile.exists());
+        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, studyId, fileId));
+        assertTrue(sourceStatsFile.exists());
 
         // The DB docs should have the field "st"
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();
-        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(jobOptions.getDbName(), null);
+        VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(dbName, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(new QueryOptions());
         assertEquals(1, iterator.next().getSourceEntries().values().iterator().next().getCohortStats().size());
 
-    }
-
-    private void initStatsLoadStepFiles() throws IOException, InterruptedException {
-        String mongoDatabase = mongoRule.restoreDumpInTemporaryDatabase(getResourceUrl(MONGO_DUMP));
-        jobOptions.setDbName(mongoDatabase);
-
-        String outputDir = temporaryFolderRule.getRoot().getAbsolutePath();
-        pipelineOptions.put(JobParametersNames.OUTPUT_DIR_STATISTICS, outputDir);
-
-        // copy stat file to load
-        copyResource(VARIANTS_FILE_NAME, outputDir);
-
-        // copy source file to load
-        copyResource(SOURCE_FILE_NAME, outputDir);
-
-        // copy transformed vcf
-        copyResource(VCF_FILE_NAME, outputDir);
     }
 
     @Before

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -36,6 +36,7 @@ import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
+import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,9 +86,9 @@ public class PopulationStatisticsGeneratorStepTest {
         mongoRule.restoreDump(getResourceUrl(MONGO_DUMP), databaseName);
 
         // and non-existent variants stats file and variantSource stats file
-        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, studyId, fileId));
+        File statsFile = new File(URLHelper.getVariantsStatsUri(statsDir, studyId, fileId));
         assertFalse(statsFile.exists());
-        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, studyId, fileId));
+        File sourceStatsFile = new File(URLHelper.getSourceStatsUri(statsDir, studyId, fileId));
         assertFalse(sourceStatsFile.exists());
 
         // When the execute method in variantsStatsCreate is executed
@@ -125,9 +126,9 @@ public class PopulationStatisticsGeneratorStepTest {
         mongoRule.restoreDump(getResourceUrl(MONGO_DUMP), databaseName);
 
         // and non-existent variants stats file and variantSource stats file
-        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, sid, fid));
+        File statsFile = new File(URLHelper.getVariantsStatsUri(statsDir, sid, fid));
         assertFalse(statsFile.exists());
-        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, sid, fid));
+        File sourceStatsFile = new File(URLHelper.getSourceStatsUri(statsDir, sid, fid));
         assertFalse(sourceStatsFile.exists());
 
         // When the execute method in variantsStatsCreate is executed

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -15,50 +15,46 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opencb.biodata.models.variant.VariantSource;
-import org.opencb.biodata.models.variant.VariantStudy;
-import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
 import uk.ac.ebi.eva.pipeline.jobs.PopulationStatisticsJob;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
-import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.opencb.opencga.storage.core.variant.VariantStorageManager.VARIANT_SOURCE;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 
 /**
  * Test for {@link PopulationStatisticsGeneratorStep}
  */
 @RunWith(SpringRunner.class)
-@TestPropertySource({"classpath:common-configuration.properties"})
+@TestPropertySource({"classpath:common-configuration.properties", "classpath:test-mongo.properties"})
 @ContextConfiguration(classes = {PopulationStatisticsJob.class, BatchTestConfiguration.class})
 public class PopulationStatisticsGeneratorStepTest {
-
     private static final String SMALL_VCF_FILE = "/small20.vcf.gz";
-    private static final String STATS_FILE_SUFFIX = ".variants.stats.json.gz";
+
     private static final String MONGO_DUMP = "/dump/VariantStatsConfigurationTest_vl";
 
     @Rule
@@ -69,24 +65,33 @@ public class PopulationStatisticsGeneratorStepTest {
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
-    @Autowired
-    private JobOptions jobOptions;
 
     @Test
-    public void statisticsGeneratorStepShouldCalculateStats() throws IOException, InterruptedException {
+    public void statisticsGeneratorStepShouldCalculateStats() throws IOException, InterruptedException, URISyntaxException {
         //Given a valid VCF input file
-        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, SMALL_VCF_FILE);
+        String databaseName = mongoRule.getRandomTemporaryDatabaseName();
+        String statsDir = temporaryFolderRule.getRoot().getAbsolutePath();
+        String studyId = "1";
+        String fileId = "1";
+
+        JobParameters jobParameters = new EvaJobParameterBuilder()
+                .inputVcf(SMALL_VCF_FILE)
+                .databaseName(databaseName)
+                .inputStudyId(studyId)
+                .inputVcfId(fileId)
+                .addString(JobParametersNames.OUTPUT_DIR_STATISTICS, statsDir).toJobParameters();
+
         //and a valid variants load step already completed
-        mongoRule.restoreDump(getResourceUrl(MONGO_DUMP), jobOptions.getDbName());
+        mongoRule.restoreDump(getResourceUrl(MONGO_DUMP), databaseName);
 
-        VariantSource source = configureVariantSource();
-        configureTempOutput();
-
-        File statsFile = getStatsFile(source);
-        assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
+        // and non-existent variants stats file and variantSource stats file
+        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, studyId, fileId));
+        assertFalse(statsFile.exists());
+        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, studyId, fileId));
+        assertFalse(sourceStatsFile.exists());
 
         // When the execute method in variantsStatsCreate is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP, jobParameters);
 
         //Then variantsStatsCreate step should complete correctly
         assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
@@ -94,6 +99,7 @@ public class PopulationStatisticsGeneratorStepTest {
 
         //and the file containing statistics should exist
         assertTrue(statsFile.exists());
+        assertTrue(sourceStatsFile.exists());
     }
 
     /**
@@ -103,47 +109,30 @@ public class PopulationStatisticsGeneratorStepTest {
     @Test
     public void statisticsGeneratorStepShouldFailIfVariantLoadStepIsNotCompleted() throws Exception {
         //Given a valid VCF input file
-        jobOptions.getPipelineOptions().put(JobParametersNames.INPUT_VCF, SMALL_VCF_FILE);
+        String databaseName = mongoRule.getRandomTemporaryDatabaseName();
+        String statsDir = temporaryFolderRule.getRoot().getAbsolutePath();
+        String sid = "sid";
+        String fid = "fid";
 
-        VariantSource source = configureVariantSource();
-        configureTempOutput();
+        JobParameters jobParameters = new EvaJobParameterBuilder()
+                .inputVcf(SMALL_VCF_FILE)
+                .databaseName(databaseName)
+                .inputStudyId(sid)
+                .inputVcfId(fid)
+                .addString(JobParametersNames.OUTPUT_DIR_STATISTICS, statsDir).toJobParameters();
 
-        File statsFile = getStatsFile(source);
-        assertFalse(statsFile.exists());  // ensure the stats file doesn't exist from previous executions
+        //and a valid variants load step already completed
+        mongoRule.restoreDump(getResourceUrl(MONGO_DUMP), databaseName);
+
+        // and non-existent variants stats file and variantSource stats file
+        File statsFile = new File(PopulationStatisticsGeneratorStep.getVariantsStatsUri(statsDir, sid, fid));
+        assertFalse(statsFile.exists());
+        File sourceStatsFile = new File(PopulationStatisticsGeneratorStep.getSourceStatsUri(statsDir, sid, fid));
+        assertFalse(sourceStatsFile.exists());
 
         // When the execute method in variantsStatsCreate is executed
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP);
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP, jobParameters);
         assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
     }
 
-    private void configureTempOutput() throws IOException {
-        String tempFolder = temporaryFolderRule.newFolder().getAbsolutePath();
-        jobOptions.getPipelineOptions().put(JobParametersNames.OUTPUT_DIR_STATISTICS, tempFolder);
-    }
-
-    private VariantSource configureVariantSource() {
-        VariantSource source = new VariantSource(
-                SMALL_VCF_FILE,
-                "1",
-                "1",
-                "studyName",
-                VariantStudy.StudyType.COLLECTION,
-                VariantSource.Aggregation.NONE);
-        jobOptions.getVariantOptions().put(VARIANT_SOURCE, source);
-        return source;
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        jobOptions.loadArgs();
-        jobOptions.setDbName(getClass().getSimpleName());
-    }
-
-    private File getStatsFile(VariantSource source) {
-        return new File(
-                Paths.get(jobOptions.getPipelineOptions().getString(JobParametersNames.OUTPUT_DIR_STATISTICS))
-                        .resolve(VariantStorageManager.buildFilename(source))
-                        + STATS_FILE_SUFFIX
-        );
-    }
 }


### PR DESCRIPTION
this is similar to https://github.com/EBIvariation/eva-pipeline/pull/70

the main change is in PopulationStatisticsGeneratorStep, where JobOptions is not used anymore. Instead, we use the containers that autowire jobParameters (InputParameters, OutputParameters, DatabaseParameters).

Tests changed accordingly to pass JobParameters to the launched job/step.