### PR TITLE
EVA-587 Unique index in "files" collection

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VcfHeaderReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VcfHeaderReader.java
@@ -72,7 +72,7 @@ public class VcfHeaderReader implements ItemReader<VariantSourceEntity> {
      * Look at the test to see how is this checked.
      */
     @Override
-    public VariantSourceEntity read() throws Exception {
+    public VariantSourceEntity read() {
         VariantVcfReader reader = new VariantVcfReader(source, file.getPath());
         reader.open();
         reader.pre();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriter.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriter.java
@@ -40,8 +40,6 @@ public class VariantMongoWriter extends MongoItemWriter<Variant> {
 
     private static final Logger logger = LoggerFactory.getLogger(VariantMongoWriter.class);
 
-    private static final String BACKGROUND_INDEX = "background";
-
     private static final String ANNOTATION_CT_SO_FIELD = "annot.ct.so";
 
     private static final String ANNOTATION_XREF_ID_FIELD = "annot.xrefs.id";
@@ -97,11 +95,11 @@ public class VariantMongoWriter extends MongoItemWriter<Variant> {
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(VariantToDBObjectConverter.CHROMOSOME_FIELD, 1)
                     .append(VariantToDBObjectConverter.START_FIELD, 1).append(VariantToDBObjectConverter.END_FIELD, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true));
 
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(VariantToDBObjectConverter.IDS_FIELD, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true));
 
         String filesStudyIdField = String.format("%s.%s", VariantToDBObjectConverter.FILES_FIELD,
                                                  VariantSourceEntryToDBObjectConverter.STUDYID_FIELD);
@@ -109,13 +107,13 @@ public class VariantMongoWriter extends MongoItemWriter<Variant> {
                                                  VariantSourceEntryToDBObjectConverter.FILEID_FIELD);
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(filesStudyIdField, 1).append(filesFileIdField, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true));
 
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(ANNOTATION_XREF_ID_FIELD, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true));
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(ANNOTATION_CT_SO_FIELD, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true));
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriter.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriter.java
@@ -62,7 +62,7 @@ public class VariantMongoWriter extends MongoItemWriter<Variant> {
         this.collection = collection;
         setTemplate(mongoOperations);
 
-        generateIndexes();
+        createIndexes();
     }
 
     @Override
@@ -93,7 +93,7 @@ public class VariantMongoWriter extends MongoItemWriter<Variant> {
         }
     }
 
-    private void generateIndexes() {
+    private void createIndexes() {
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(VariantToDBObjectConverter.CHROMOSOME_FIELD, 1)
                     .append(VariantToDBObjectConverter.START_FIELD, 1).append(VariantToDBObjectConverter.END_FIELD, 1),

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriter.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriter.java
@@ -22,17 +22,14 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.util.Assert;
 
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 /**
  * Write a list of {@link VariantSourceEntity} into MongoDB
  */
 public class VariantSourceEntityMongoWriter extends MongoItemWriter<VariantSourceEntity> {
 
-    private static final String BACKGROUND_INDEX = "background";
-
-    private static final String UNIQUE_INDEX = "unique";
-
-    private static final String INDEX_NAME = "name";
+    public static final String UNIQUE_FILE_INDEX_NAME = "unique_file";
 
     private MongoOperations mongoOperations;
 
@@ -55,7 +52,7 @@ public class VariantSourceEntityMongoWriter extends MongoItemWriter<VariantSourc
         mongoOperations.getCollection(collection).createIndex(
                 new BasicDBObject(VariantSourceEntity.STUDYID_FIELD, 1).append(VariantSourceEntity.FILEID_FIELD, 1)
                     .append(VariantSourceEntity.FILENAME_FIELD, 1),
-                new BasicDBObject(BACKGROUND_INDEX, true).append(UNIQUE_INDEX, true)
-                    .append(INDEX_NAME, "unique_file"));
+                new BasicDBObject(MongoDBHelper.BACKGROUND_INDEX, true).append(MongoDBHelper.UNIQUE_INDEX, true)
+                    .append(MongoDBHelper.INDEX_NAME, UNIQUE_FILE_INDEX_NAME));
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/MongoDBHelper.java
@@ -26,7 +26,13 @@ import java.util.List;
 
 
 public class MongoDBHelper {
-    
+
+    public static final String BACKGROUND_INDEX = "background";
+
+    public static final String UNIQUE_INDEX = "unique";
+
+    public static final String INDEX_NAME = "name";
+
     private MongoDBHelper() {
         // Can't be instantiated
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -34,6 +34,7 @@ import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VariantWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -123,7 +124,8 @@ public class VariantMongoWriterTest {
         assertEquals(expectedIndexes, createdIndexes);
 
         indexInfo.stream().filter(index -> !("_id_".equals(index.get("name").toString())))
-                          .forEach(index -> assertEquals("true", index.get("background").toString()));
+                          .forEach(index -> assertEquals("true",
+                                                         index.get(MongoDBHelper.BACKGROUND_INDEX).toString()));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -40,6 +40,7 @@ import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.utils.MongoDBHelper;
 
 import java.io.File;
 import java.util.Arrays;
@@ -167,14 +168,15 @@ public class VariantSourceEntityMongoWriterTest {
         Set<String> createdIndexes = indexInfo.stream().map(index -> index.get("name").toString())
                 .collect(Collectors.toSet());
         Set<String> expectedIndexes = new HashSet<>();
-        expectedIndexes.addAll(Arrays.asList("unique_file", "_id_"));
+        expectedIndexes.addAll(Arrays.asList(VariantSourceEntityMongoWriter.UNIQUE_FILE_INDEX_NAME, "_id_"));
         assertEquals(expectedIndexes, createdIndexes);
 
         DBObject uniqueIndex = indexInfo.stream().filter(
-                index -> ("unique_file".equals(index.get("name").toString()))).findFirst().get();
+                index -> (VariantSourceEntityMongoWriter.UNIQUE_FILE_INDEX_NAME.equals(index.get("name").toString())))
+                        .findFirst().get();
         assertNotNull(uniqueIndex);
-        assertEquals("true", uniqueIndex.get("unique").toString());
-        assertEquals("true", uniqueIndex.get("background").toString());
+        assertEquals("true", uniqueIndex.get(MongoDBHelper.UNIQUE_INDEX).toString());
+        assertEquals("true", uniqueIndex.get(MongoDBHelper.BACKGROUND_INDEX).toString());
     }
 
     private VariantSourceEntity getVariantSourceEntity() {


### PR DESCRIPTION
A new unique, background index is now created in the "files" collection, on the following fields:

* File ID (`fid`)
* Filename (`fname`)
* Study ID (`sid`)

Both file ID and name because the file ID matches an ERZ, which can contain multiple files. We should consider renaming this field in the future.