### PR TITLE
EVA-634 Refactor of MongoConfiguration

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -16,17 +16,11 @@
 package uk.ac.ebi.eva.pipeline.configuration.readers;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
-
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
-
-import java.net.UnknownHostException;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIANTS_READER;
 
@@ -34,17 +28,12 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIA
  * Configuration to inject a NonAnnotatedVariantsMongoReader bean that reads from a mongo database in the pipeline
  */
 @Configuration
-@Import({ MongoConfiguration.class })
 public class NonAnnotatedVariantsMongoReaderConfiguration {
-
-    @Autowired
-    private MongoConfiguration mongoConfiguration;
 
     @Bean(NON_ANNOTATED_VARIANTS_READER)
     @StepScope
-    public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(DatabaseParameters databaseParameters)
-            throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
+    public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(MongoOperations mongoOperations,
+                                                                           DatabaseParameters databaseParameters) {
         return new NonAnnotatedVariantsMongoReader(mongoOperations, databaseParameters.getCollectionVariantsName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -44,8 +44,7 @@ public class NonAnnotatedVariantsMongoReaderConfiguration {
     @StepScope
     public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(DatabaseParameters databaseParameters)
             throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
-                databaseParameters.getDatabaseName(), databaseParameters.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
         return new NonAnnotatedVariantsMongoReader(mongoOperations, databaseParameters.getCollectionVariantsName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantAnnotationReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantAnnotationReaderConfiguration.java
@@ -19,6 +19,7 @@ import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.eva.pipeline.io.readers.AnnotationFlatFileReader;
 import uk.ac.ebi.eva.pipeline.parameters.AnnotationParameters;
 
@@ -27,6 +28,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_
 /**
  * Configuration to inject a AnnotationFlatFileReader as a Variant Annotation Reader in the pipeline.
  */
+@Configuration
 public class VariantAnnotationReaderConfiguration {
 
     @Bean(VARIANT_ANNOTATION_READER)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -42,8 +42,7 @@ public class GeneWriterConfiguration {
     @Bean(GENE_WRITER)
     @StepScope
     public ItemWriter<FeatureCoordinates> geneWriter(DatabaseParameters databaseParameters) throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
-                databaseParameters.getDatabaseName(), databaseParameters.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
         return new GeneWriter(mongoOperations, databaseParameters.getCollectionFeaturesName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/GeneWriterConfiguration.java
@@ -17,32 +17,22 @@ package uk.ac.ebi.eva.pipeline.configuration.writers;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoOperations;
-
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.GeneWriter;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 
-import java.net.UnknownHostException;
-
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENE_WRITER;
 
 @Configuration
-@Import({ MongoConfiguration.class })
 public class GeneWriterConfiguration {
-
-    @Autowired
-    private MongoConfiguration mongoConfiguration;
 
     @Bean(GENE_WRITER)
     @StepScope
-    public ItemWriter<FeatureCoordinates> geneWriter(DatabaseParameters databaseParameters) throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
+    public ItemWriter<FeatureCoordinates> geneWriter(MongoOperations mongoOperations,
+                                                     DatabaseParameters databaseParameters) {
         return new GeneWriter(mongoOperations, databaseParameters.getCollectionFeaturesName());
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -18,35 +18,24 @@ package uk.ac.ebi.eva.pipeline.configuration.writers;
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
-
 import uk.ac.ebi.eva.pipeline.Application;
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.VepAnnotationMongoWriter;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
-
-import java.net.UnknownHostException;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_WRITER;
 
 @Configuration
-@Import({MongoConfiguration.class})
 public class VariantAnnotationWriterConfiguration {
-
-    @Autowired
-    private MongoConfiguration mongoConfiguration;
 
     @Bean(VARIANT_ANNOTATION_WRITER)
     @StepScope
     @Profile(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
-    public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(DatabaseParameters databaseParameters)
-            throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
+    public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(MongoOperations mongoOperations,
+                                                                     DatabaseParameters databaseParameters) {
         return new VepAnnotationMongoWriter(mongoOperations, databaseParameters.getCollectionVariantsName());
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantAnnotationWriterConfiguration.java
@@ -46,8 +46,7 @@ public class VariantAnnotationWriterConfiguration {
     @Profile(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
     public ItemWriter<VariantAnnotation> variantAnnotationItemWriter(DatabaseParameters databaseParameters)
             throws UnknownHostException {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
-                databaseParameters.getDatabaseName(), databaseParameters.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
         return new VepAnnotationMongoWriter(mongoOperations, databaseParameters.getCollectionVariantsName());
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -47,8 +47,7 @@ public class VariantWriterConfiguration {
     @Profile(Application.VARIANT_WRITER_MONGO_PROFILE)
     public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions, DatabaseParameters databaseParameters) throws
             Exception {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
-                databaseParameters.getDatabaseName(), databaseParameters.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
 
         return new VariantMongoWriter(databaseParameters.getCollectionVariantsName(),
                 mongoOperations,

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -15,48 +15,37 @@
  */
 package uk.ac.ebi.eva.pipeline.configuration.writers;
 
-import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_WRITER;
-
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
-
 import uk.ac.ebi.eva.commons.models.data.Variant;
 import uk.ac.ebi.eva.pipeline.Application;
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.writers.VariantMongoWriter;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 
-@Configuration
-@Import({ MongoConfiguration.class })
-public class VariantWriterConfiguration {
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_WRITER;
 
-    @Autowired
-    private MongoConfiguration mongoConfiguration;
+@Configuration
+public class VariantWriterConfiguration {
 
     @Bean(VARIANT_WRITER)
     @StepScope
     @Profile(Application.VARIANT_WRITER_MONGO_PROFILE)
-    public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions, DatabaseParameters databaseParameters) throws
-            Exception {
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
-
-        return new VariantMongoWriter(databaseParameters.getCollectionVariantsName(),
-                mongoOperations,
+    public ItemWriter<Variant> variantMongoWriter(JobOptions jobOptions, MongoOperations mongoOperations,
+                                                  DatabaseParameters databaseParameters) {
+        return new VariantMongoWriter(databaseParameters.getCollectionVariantsName(), mongoOperations,
                 variantToMongoDbObjectConverter(jobOptions));
     }
 
     @Bean
     @StepScope
-    public VariantToMongoDbObjectConverter variantToMongoDbObjectConverter(JobOptions jobOptions) throws Exception {
+    public VariantToMongoDbObjectConverter variantToMongoDbObjectConverter(JobOptions jobOptions) {
         return new VariantToMongoDbObjectConverter(
                 jobOptions.getVariantOptions().getBoolean(VariantStorageManager.INCLUDE_STATS),
                 jobOptions.getVariantOptions().getBoolean(VariantStorageManager.CALCULATE_STATS),

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -33,8 +33,7 @@ import java.net.UnknownHostException;
  */
 public class NonAnnotatedVariantsMongoReader extends MongoDbCursorItemReader {
 
-    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName)
-            throws UnknownHostException {
+    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName) {
         super();
 
         setTemplate(template);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
@@ -41,7 +41,7 @@ public class CalculateStatisticsStep {
 
     @Bean
     @StepScope
-    PopulationStatisticsGeneratorStep populationStatisticsGeneratorStep() {
+    public PopulationStatisticsGeneratorStep populationStatisticsGeneratorStep() {
         return new PopulationStatisticsGeneratorStep();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CreateDatabaseIndexesStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CreateDatabaseIndexesStep.java
@@ -40,7 +40,7 @@ public class CreateDatabaseIndexesStep {
 
     @Bean
     @StepScope
-    IndexesGeneratorStep indexesGeneratorStep() {
+    public IndexesGeneratorStep indexesGeneratorStep() {
         return new IndexesGeneratorStep();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
@@ -40,7 +40,7 @@ public class GenerateVepAnnotationStep {
 
     @Bean
     @StepScope
-    VepAnnotationGeneratorStep vepAnnotationGeneratorStep() {
+    public VepAnnotationGeneratorStep vepAnnotationGeneratorStep() {
         return new VepAnnotationGeneratorStep();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
@@ -40,7 +40,7 @@ public class LoadFileStep {
 
     @Bean
     @StepScope
-    FileLoaderStep fileLoaderStep() {
+    public FileLoaderStep fileLoaderStep() {
         return new FileLoaderStep();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
@@ -23,9 +23,6 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.FileLoaderStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
@@ -37,7 +34,6 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_FILE_STEP;
  */
 @Configuration
 @EnableBatchProcessing
-@Import({ MongoConfiguration.class })
 public class LoadFileStep {
 
     private static final Logger logger = LoggerFactory.getLogger(LoadFileStep.class);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
@@ -23,7 +23,6 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsLoaderStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
@@ -41,7 +40,7 @@ public class LoadStatisticsStep {
 
     @Bean
     @StepScope
-    PopulationStatisticsLoaderStep populationStatisticsLoaderStep() {
+    public PopulationStatisticsLoaderStep populationStatisticsLoaderStep() {
         return new PopulationStatisticsLoaderStep();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
@@ -64,8 +64,7 @@ public class FileLoaderStep implements Tasklet {
         vcfHeaderReader.open(null);
         VariantSourceEntity variantSourceEntity = vcfHeaderReader.read();
 
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(
-                dbParameters.getDatabaseName(), dbParameters.getMongoConnection());
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbParameters.getDatabaseName());
 
         VariantSourceEntityMongoWriter variantSourceEntityMongoWriter = new VariantSourceEntityMongoWriter(
                 mongoOperations, dbParameters.getCollectionFilesName());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/FileLoaderStep.java
@@ -21,9 +21,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
-
 import uk.ac.ebi.eva.commons.models.data.VariantSourceEntity;
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.VcfHeaderReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VariantSourceEntityMongoWriter;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
@@ -43,7 +41,7 @@ import java.util.Collections;
 public class FileLoaderStep implements Tasklet {
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoOperations mongoOperations;
 
     @Autowired
     private InputParameters inputParameters;
@@ -63,8 +61,6 @@ public class FileLoaderStep implements Tasklet {
                 inputParameters.getVcfAggregation());
         vcfHeaderReader.open(null);
         VariantSourceEntity variantSourceEntity = vcfHeaderReader.read();
-
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbParameters.getDatabaseName());
 
         VariantSourceEntityMongoWriter variantSourceEntityMongoWriter = new VariantSourceEntityMongoWriter(
                 mongoOperations, dbParameters.getCollectionFilesName());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
@@ -22,8 +22,6 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
-
-import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 
 /**
@@ -34,17 +32,16 @@ import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 public class IndexesGeneratorStep implements Tasklet {
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoOperations mongoOperations;
 
     @Autowired
     private DatabaseParameters databaseParameters;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
-        operations.getCollection(databaseParameters.getCollectionFeaturesName())
-                .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
-
+        mongoOperations.getCollection(databaseParameters.getCollectionFeaturesName())
+                .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true)
+                        .append("background", true));
         return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/tasklets/IndexesGeneratorStep.java
@@ -41,8 +41,7 @@ public class IndexesGeneratorStep implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        MongoOperations operations = mongoConfiguration.getMongoOperations(
-                databaseParameters.getDatabaseName(), databaseParameters.getMongoConnection());
+        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseParameters.getDatabaseName());
         operations.getCollection(databaseParameters.getCollectionFeaturesName())
                 .createIndex(new BasicDBObject("name", 1), new BasicDBObject("sparse", true).append("background", true));
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -63,15 +63,12 @@ public class NonAnnotatedVariantsMongoReaderTest {
     @Autowired
     private MongoConfiguration mongoConfiguration;
 
-    @Autowired
-    private MongoConnection mongoConnection;
-
     @Test
     public void shouldReadVariantsWithoutAnnotationField() throws Exception {
         ExecutionContext executionContext = MetaDataInstanceFactory.createStepExecution().getExecutionContext();
         String databaseName = insertDocuments(COLLECTION_VARIANTS_NAME);
 
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
 
         NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
                 mongoOperations, COLLECTION_VARIANTS_NAME);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -23,14 +23,13 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.commons.models.converters.data.VariantToDBObjectConverter;
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.readers.NonAnnotatedVariantsMongoReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
@@ -50,25 +49,29 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringRunner.class)
 @ActiveProfiles("variant-annotation-mongo")
 @TestPropertySource({"classpath:annotation.properties", "classpath:test-mongo.properties"})
-@ContextConfiguration(classes = {NonAnnotatedVariantsMongoReaderConfiguration.class, BaseTestConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class NonAnnotatedVariantsMongoReaderTest {
 
     private static final String COLLECTION_VARIANTS_NAME = "variants";
 
     private static final int EXPECTED_NON_ANNOTATED_VARIANTS = 1;
 
-    @Rule
-    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
+    @Autowired
+    private MongoConnection mongoConnection;
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoMappingContext mongoMappingContext;
+
+    @Rule
+    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Test
     public void shouldReadVariantsWithoutAnnotationField() throws Exception {
         ExecutionContext executionContext = MetaDataInstanceFactory.createStepExecution().getExecutionContext();
         String databaseName = insertDocuments(COLLECTION_VARIANTS_NAME);
 
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
 
         NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
                 mongoOperations, COLLECTION_VARIANTS_NAME);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -59,16 +59,13 @@ public class GeneWriterTest {
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Autowired
-    private MongoConnection mongoConnection;
-
-    @Autowired
     private MongoConfiguration mongoConfiguration;
 
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
 
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
 
         GeneWriter geneWriter = new GeneWriter(mongoOperations, COLLECTION_FEATURES_NAME);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/GeneWriterTest.java
@@ -24,12 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.writers.GeneWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
@@ -50,22 +49,25 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:initialize-database.properties", "classpath:test-mongo.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class, GeneWriterConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class GeneWriterTest {
 
     private static final String COLLECTION_FEATURES_NAME = "features";
 
-    @Rule
-    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
+    @Autowired
+    private MongoConnection mongoConnection;
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoMappingContext mongoMappingContext;
+
+    @Rule
+    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
 
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection, mongoMappingContext);
 
         GeneWriter geneWriter = new GeneWriter(mongoOperations, COLLECTION_FEATURES_NAME);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -26,10 +26,10 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.item.file.mapping.JsonLineMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.pipeline.model.PopulationStatistics;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
@@ -51,18 +51,21 @@ import static org.junit.Assert.assertNotNull;
  * {@link StatisticsMongoWriter}
  * input: a List of {@link PopulationStatistics} to each call of `.write()`
  * output: the FeatureCoordinates get written in mongo, with at least: chromosome, start and end.
- *
+ * <p>
  * TODO Replace MongoDBHelper with StatisticsMongoWriterConfiguration in ContextConfiguration when the class exists
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:common-configuration.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class, MongoConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class StatisticsMongoWriterTest {
 
     private static final String COLLECTION_STATS_NAME = "populationStatistics";
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoConnection mongoConnection;
+
+    @Autowired
+    private MongoMappingContext mongoMappingContext;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -167,7 +170,8 @@ public class StatisticsMongoWriterTest {
     }
 
     public StatisticsMongoWriter getStatisticsMongoWriter(String databaseName) throws UnknownHostException {
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations operations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         StatisticsMongoWriter statisticsMongoWriter = new StatisticsMongoWriter(operations, COLLECTION_STATS_NAME);
         return statisticsMongoWriter;
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/StatisticsMongoWriterTest.java
@@ -67,9 +67,6 @@ public class StatisticsMongoWriterTest {
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
-    @Autowired
-    private MongoConnection mongoConnection;
-
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         List<PopulationStatistics> populationStatisticsList = buildPopulationStatsList();
@@ -170,7 +167,7 @@ public class StatisticsMongoWriterTest {
     }
 
     public StatisticsMongoWriter getStatisticsMongoWriter(String databaseName) throws UnknownHostException {
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
         StatisticsMongoWriter statisticsMongoWriter = new StatisticsMongoWriter(operations, COLLECTION_STATS_NAME);
         return statisticsMongoWriter;
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -25,13 +25,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.commons.models.data.Variant;
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.writers.VariantWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.model.converters.data.VariantToMongoDbObjectConverter;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
@@ -58,11 +57,8 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(SpringRunner.class)
 @TestPropertySource({"classpath:common-configuration.properties", "classpath:test-mongo.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class, VariantWriterConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class VariantMongoWriterTest {
-
-    @Autowired
-    private MongoConfiguration mongoConfiguration;
 
     private static final List<? extends Variant> EMPTY_LIST = new ArrayList<>();
 
@@ -71,13 +67,20 @@ public class VariantMongoWriterTest {
 
     private final String collectionName = "variants";
 
+    @Autowired
+    private MongoConnection mongoConnection;
+
+    @Autowired
+    private MongoMappingContext mongoMappingContext;
+
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Test
     public void noVariantsNothingShouldBeWritten() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(dbName, mongoConnection,
+                mongoMappingContext);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -93,7 +96,8 @@ public class VariantMongoWriterTest {
         Variant variant2 = new Variant("2", 3, 4, "C", "G");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(dbName, mongoConnection,
+                mongoMappingContext);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         BasicDBObject dbObject = new BasicDBObject();
@@ -111,7 +115,8 @@ public class VariantMongoWriterTest {
     @Test
     public void indexesShouldBeCreatedInBackground() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(dbName, mongoConnection,
+                mongoMappingContext);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -136,7 +141,8 @@ public class VariantMongoWriterTest {
         Variant variant1 = new Variant("1", 1, 2, "A", "T");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(dbName, mongoConnection,
+                mongoMappingContext);
 
         BasicDBObject dbObject = new BasicDBObject();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantMongoWriterTest.java
@@ -64,9 +64,6 @@ public class VariantMongoWriterTest {
     @Autowired
     private MongoConfiguration mongoConfiguration;
 
-    @Autowired
-    private MongoConnection mongoConnection;
-
     private static final List<? extends Variant> EMPTY_LIST = new ArrayList<>();
 
     private VariantToMongoDbObjectConverter variantToMongoDbObjectConverter =
@@ -80,7 +77,7 @@ public class VariantMongoWriterTest {
     @Test
     public void noVariantsNothingShouldBeWritten() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -96,7 +93,7 @@ public class VariantMongoWriterTest {
         Variant variant2 = new Variant("2", 3, 4, "C", "G");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         BasicDBObject dbObject = new BasicDBObject();
@@ -114,7 +111,7 @@ public class VariantMongoWriterTest {
     @Test
     public void indexesShouldBeCreatedInBackground() throws UnknownHostException {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
         DBCollection dbCollection = mongoOperations.getCollection(collectionName);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations,
@@ -139,7 +136,7 @@ public class VariantMongoWriterTest {
         Variant variant1 = new Variant("1", 1, 2, "A", "T");
 
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(dbName);
 
         BasicDBObject dbObject = new BasicDBObject();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -85,9 +85,6 @@ public class VariantSourceEntityMongoWriterTest {
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Autowired
-    private MongoConnection mongoConnection;
-
-    @Autowired
     private MongoConfiguration mongoConfiguration;
 
     private String input;
@@ -95,7 +92,7 @@ public class VariantSourceEntityMongoWriterTest {
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(
@@ -134,7 +131,7 @@ public class VariantSourceEntityMongoWriterTest {
     @Test
     public void shouldWriteSamplesWithDotsInName() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VariantSourceEntityMongoWriterTest.java
@@ -23,6 +23,7 @@ import org.opencb.biodata.models.variant.VariantSource;
 import org.opencb.biodata.models.variant.VariantStudy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -81,18 +82,22 @@ public class VariantSourceEntityMongoWriterTest {
 
     private static final VariantSource.Aggregation AGGREGATION = VariantSource.Aggregation.NONE;
 
-    @Rule
-    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
+    @Autowired
+    private MongoConnection mongoConnection;
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoMappingContext mongoMappingContext;
+
+    @Rule
+    public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     private String input;
 
     @Test
     public void shouldWriteAllFieldsIntoMongoDb() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(
@@ -131,7 +136,8 @@ public class VariantSourceEntityMongoWriterTest {
     @Test
     public void shouldWriteSamplesWithDotsInName() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter(
@@ -161,7 +167,8 @@ public class VariantSourceEntityMongoWriterTest {
     @Test
     public void shouldCreateUniqueFileIndex() throws Exception {
         String databaseName = mongoRule.getRandomTemporaryDatabaseName();
-        MongoOperations mongoOperations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
 
         VariantSourceEntityMongoWriter filesWriter = new VariantSourceEntityMongoWriter( mongoOperations,

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -27,14 +27,13 @@ import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantAnnotationConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.commons.models.converters.data.VariantToDBObjectConverter;
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.writers.VariantAnnotationWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.AnnotationLineMapper;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 import uk.ac.ebi.eva.test.configuration.BaseTestConfiguration;
@@ -61,13 +60,16 @@ import static uk.ac.ebi.eva.test.data.VepOutputContent.vepOutputContent;
 @RunWith(SpringRunner.class)
 @ActiveProfiles("variant-annotation-mongo")
 @TestPropertySource({"classpath:annotation.properties", "classpath:test-mongo.properties"})
-@ContextConfiguration(classes = {BaseTestConfiguration.class, VariantAnnotationWriterConfiguration.class})
+@ContextConfiguration(classes = {BaseTestConfiguration.class})
 public class VepAnnotationMongoWriterTest {
 
     private static final String COLLECTION_VARIANTS_NAME = "variants";
 
     @Autowired
-    private MongoConfiguration mongoConfiguration;
+    private MongoConnection mongoConnection;
+
+    @Autowired
+    private MongoMappingContext mongoMappingContext;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
@@ -91,7 +93,8 @@ public class VepAnnotationMongoWriterTest {
         writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations operations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         annotationWriter = new VepAnnotationMongoWriter(operations, COLLECTION_VARIANTS_NAME);
         annotationWriter.write(annotations);
 
@@ -150,7 +153,8 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
+        MongoOperations operations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
+                mongoMappingContext);
         annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
 
         annotationWriter.write(annotationSet1);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/writers/VepAnnotationMongoWriterTest.java
@@ -72,10 +72,6 @@ public class VepAnnotationMongoWriterTest {
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
-    @Autowired
-    private MongoConnection mongoConnection;
-
-
     private DBObjectToVariantAnnotationConverter converter;
     private VepAnnotationMongoWriter annotationWriter;
     private AnnotationLineMapper AnnotationLineMapper;
@@ -95,7 +91,7 @@ public class VepAnnotationMongoWriterTest {
         writeIdsIntoMongo(annotations, variants);
 
         // now, load the annotation
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
         annotationWriter = new VepAnnotationMongoWriter(operations, COLLECTION_VARIANTS_NAME);
         annotationWriter.write(annotations);
 
@@ -154,7 +150,7 @@ public class VepAnnotationMongoWriterTest {
         }
 
         // now, load the annotation
-        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName, mongoConnection);
+        MongoOperations operations = mongoConfiguration.getMongoOperations(databaseName);
         annotationWriter = new VepAnnotationMongoWriter(operations, dbCollectionVariantsName);
 
         annotationWriter.write(annotationSet1);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.pipeline.Application;
 import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.test.utils.JobTestUtils;

--- a/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/test/configuration/BaseTestConfiguration.java
@@ -18,6 +18,7 @@ package uk.ac.ebi.eva.test.configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 
@@ -32,5 +33,10 @@ public class BaseTestConfiguration {
     @Bean
     public MongoConnection mongoConnection() {
         return new MongoConnection();
+    }
+
+    @Bean
+    public MongoMappingContext mongoMappingContext() {
+        return new MongoMappingContext();
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/test/configuration/BatchTestConfiguration.java
+++ b/src/test/java/uk/ac/ebi/eva/test/configuration/BatchTestConfiguration.java
@@ -5,10 +5,13 @@ import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
 
 @Configuration
 @EnableBatchProcessing
 @ComponentScan(basePackages = {"uk.ac.ebi.eva.pipeline.parameters"})
+@Import({MongoConfiguration.class})
 public class BatchTestConfiguration extends BaseTestConfiguration {
 
     @Bean


### PR DESCRIPTION
MongoConfiguration now is a configuration and is also used with autowiring which is not consistent.

MongoConfiguration now has been refactored so that MongoOperation is injected into the spring context with StepScope. This way the configuration of reader and writers can be simplified. The code has been separated so that we can use static methods from MongoConfigurations and use them in tests where we need to create specific conections.