### PR TITLE
Refactored JobOptions to remove all innecesary injections and elements

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/writers/VariantWriterConfiguration.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.ebi.eva.pipeline.configuration.writers;
 
-import org.opencb.opencga.storage.core.variant.VariantStorageManager;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +46,10 @@ public class VariantWriterConfiguration {
     @StepScope
     public VariantToMongoDbObjectConverter variantToMongoDbObjectConverter(JobOptions jobOptions) {
         return new VariantToMongoDbObjectConverter(
-                jobOptions.getVariantOptions().getBoolean(VariantStorageManager.INCLUDE_STATS),
-                jobOptions.getVariantOptions().getBoolean(VariantStorageManager.CALCULATE_STATS),
-                jobOptions.getVariantOptions().getBoolean(VariantStorageManager.INCLUDE_SAMPLES),
-                (VariantStorageManager.IncludeSrc) jobOptions.getVariantOptions()
-                        .get(VariantStorageManager.INCLUDE_SRC));
+                jobOptions.isIncludeStats(),
+                jobOptions.isCalculateStats(),
+                jobOptions.isIncludeSamples(),
+                jobOptions.getIncludeSourceLine());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
-
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlowOptional;
 import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
@@ -60,8 +59,6 @@ public class AggregatedVcfJob {
 
     //job default settings
     private static final boolean INCLUDE_SAMPLES = false;
-
-    private static final boolean COMPRESS_GENOTYPES = false;
 
     private static final boolean CALCULATE_STATS = true;
 
@@ -102,7 +99,6 @@ public class AggregatedVcfJob {
     @Scope("prototype")
     JobExecutionListener aggregatedJobListener() {
         return new VariantOptionsConfigurerListener(INCLUDE_SAMPLES,
-                COMPRESS_GENOTYPES,
                 CALCULATE_STATS,
                 INCLUDE_STATS);
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
@@ -33,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
-
 import uk.ac.ebi.eva.pipeline.jobs.flows.ParallelStatisticsAndAnnotationFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
@@ -61,8 +60,6 @@ public class GenotypedVcfJob {
 
     //job default settings
     private static final boolean INCLUDE_SAMPLES = true;
-
-    private static final boolean COMPRESS_GENOTYPES = true;
 
     private static final boolean CALCULATE_STATS = false;
 
@@ -102,7 +99,6 @@ public class GenotypedVcfJob {
     @JobScope
     public JobExecutionListener genotypedJobListener() {
         return new VariantOptionsConfigurerListener(INCLUDE_SAMPLES,
-                COMPRESS_GENOTYPES,
                 CALCULATE_STATS,
                 INCLUDE_STATS);
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStep.java
@@ -17,7 +17,6 @@
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
 import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
-import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -37,7 +36,6 @@ import uk.ac.ebi.eva.pipeline.io.readers.AnnotationFlatFileReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VepAnnotationMongoWriter;
 import uk.ac.ebi.eva.pipeline.listeners.SkippedItemListener;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_VEP_ANNOTATION_STEP;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_ANNOTATION_READER;
@@ -76,16 +74,12 @@ public class AnnotationLoaderStep {
     public Step loadVepAnnotationStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + LOAD_VEP_ANNOTATION_STEP + "'");
 
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
-        final int chunkSize = pipelineOptions.getInt(JobParametersNames.CONFIG_CHUNK_SIZE);
-
         return stepBuilderFactory.get(LOAD_VEP_ANNOTATION_STEP)
-                .<VariantAnnotation, VariantAnnotation>chunk(chunkSize)
+                .<VariantAnnotation, VariantAnnotation>chunk(jobOptions.getChunkSize())
                 .reader(variantAnnotationReader)
                 .writer(variantAnnotationItemWriter)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
-                .allowStartIfComplete(startIfcomplete)
+                .allowStartIfComplete(jobOptions.isAllowStartIfComplete())
                 .listener(new SkippedItemListener())
                 .build();
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CalculateStatisticsStep.java
@@ -23,7 +23,6 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 import uk.ac.ebi.eva.utils.TaskletUtils;
@@ -49,7 +48,7 @@ public class CalculateStatisticsStep {
     public TaskletStep calculateStatisticsStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + CALCULATE_STATISTICS_STEP + "'");
         return TaskletUtils.generateStep(stepBuilderFactory, CALCULATE_STATISTICS_STEP,
-                populationStatisticsGeneratorStep(), jobOptions);
+                populationStatisticsGeneratorStep(), jobOptions.isAllowStartIfComplete());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CreateDatabaseIndexesStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/CreateDatabaseIndexesStep.java
@@ -48,7 +48,7 @@ public class CreateDatabaseIndexesStep {
     public TaskletStep createDatabaseIndexesStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + CREATE_DATABASE_INDEXES_STEP + "'");
         return TaskletUtils.generateStep(stepBuilderFactory, CREATE_DATABASE_INDEXES_STEP, indexesGeneratorStep(),
-                jobOptions);
+                jobOptions.isAllowStartIfComplete());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GeneLoaderStep.java
@@ -16,7 +16,6 @@
 
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -30,7 +29,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
 import uk.ac.ebi.eva.pipeline.configuration.readers.GeneReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.GeneWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.mappers.GeneLineMapper;
@@ -40,7 +38,6 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.processors.GeneFilterProcessor;
 import uk.ac.ebi.eva.pipeline.listeners.SkippedItemListener;
 import uk.ac.ebi.eva.pipeline.model.FeatureCoordinates;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENES_LOAD_STEP;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENE_READER;
@@ -78,16 +75,13 @@ public class GeneLoaderStep {
     public Step genesLoadStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + GENES_LOAD_STEP + "'");
 
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
-
         return stepBuilderFactory.get(GENES_LOAD_STEP)
-                .<FeatureCoordinates, FeatureCoordinates>chunk(jobOptions.getPipelineOptions().getInt(JobParametersNames.CONFIG_CHUNK_SIZE))
+                .<FeatureCoordinates, FeatureCoordinates>chunk(jobOptions.getChunkSize())
                 .reader(reader)
                 .processor(new GeneFilterProcessor())
                 .writer(writer)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
-                .allowStartIfComplete(startIfcomplete)
+                .allowStartIfComplete(jobOptions.isAllowStartIfComplete())
                 .listener(new SkippedItemListener())
                 .build();
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
@@ -48,7 +48,7 @@ public class GenerateVepAnnotationStep {
     public TaskletStep generateVepAnnotationStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + GENERATE_VEP_ANNOTATION_STEP + "'");
         return TaskletUtils.generateStep(stepBuilderFactory, GENERATE_VEP_ANNOTATION_STEP,
-                vepAnnotationGeneratorStep(), jobOptions);
+                vepAnnotationGeneratorStep(), jobOptions.isAllowStartIfComplete());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStep.java
@@ -47,7 +47,8 @@ public class LoadFileStep {
     @Bean(LOAD_FILE_STEP)
     public TaskletStep loadFileStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + LOAD_FILE_STEP + "'");
-        return TaskletUtils.generateStep(stepBuilderFactory, LOAD_FILE_STEP, fileLoaderStep(), jobOptions);
+        return TaskletUtils.generateStep(stepBuilderFactory, LOAD_FILE_STEP, fileLoaderStep(),
+                jobOptions.isAllowStartIfComplete());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadStatisticsStep.java
@@ -48,7 +48,7 @@ public class LoadStatisticsStep {
     public TaskletStep loadStatisticsStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + LOAD_STATISTICS_STEP + "'");
         return TaskletUtils.generateStep(stepBuilderFactory, LOAD_STATISTICS_STEP,
-                populationStatisticsLoaderStep(), jobOptions);
+                populationStatisticsLoaderStep(), jobOptions.isAllowStartIfComplete());
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStep.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -34,7 +33,6 @@ import uk.ac.ebi.eva.pipeline.configuration.readers.VcfReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VariantWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.listeners.SkippedItemListener;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.LOAD_VARIANTS_STEP;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANT_READER;
@@ -65,15 +63,12 @@ public class VariantLoaderStep {
     public Step loadVariantsStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + LOAD_VARIANTS_STEP + "'");
 
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
-
         return stepBuilderFactory.get(LOAD_VARIANTS_STEP)
-                .<Variant, Variant>chunk(jobOptions.getPipelineOptions().getInt(JobParametersNames.CONFIG_CHUNK_SIZE))
+                .<Variant, Variant>chunk(jobOptions.getChunkSize())
                 .reader(reader)
                 .writer(variantWriter)
                 .faultTolerant().skipLimit(50).skip(FlatFileParseException.class)
-                .allowStartIfComplete(startIfcomplete)
+                .allowStartIfComplete(jobOptions.isAllowStartIfComplete())
                 .listener(new SkippedItemListener())
                 .build();
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
@@ -16,7 +16,6 @@
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
 import com.mongodb.DBObject;
-import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
@@ -35,7 +34,6 @@ import uk.ac.ebi.eva.pipeline.io.writers.VepInputFlatFileWriter;
 import uk.ac.ebi.eva.pipeline.jobs.steps.processors.AnnotationProcessor;
 import uk.ac.ebi.eva.pipeline.model.VariantWrapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENERATE_VEP_INPUT_STEP;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIANTS_READER;
@@ -75,16 +73,12 @@ public class VepInputGeneratorStep {
     public Step generateVepInputStep(StepBuilderFactory stepBuilderFactory, JobOptions jobOptions) {
         logger.debug("Building '" + GENERATE_VEP_INPUT_STEP + "'");
 
-        ObjectMap pipelineOptions = jobOptions.getPipelineOptions();
-        boolean startIfcomplete = pipelineOptions.getBoolean(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW);
-        int chunkSize = pipelineOptions.getInt(JobParametersNames.CONFIG_CHUNK_SIZE);
-
         return stepBuilderFactory.get(GENERATE_VEP_INPUT_STEP)
-                .<DBObject, VariantWrapper>chunk(chunkSize)
+                .<DBObject, VariantWrapper>chunk(jobOptions.getChunkSize())
                 .reader(reader)
                 .processor(new AnnotationProcessor())
                 .writer(writer)
-                .allowStartIfComplete(startIfcomplete)
+                .allowStartIfComplete(jobOptions.isAllowStartIfComplete())
                 .build();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/listeners/VariantOptionsConfigurerListener.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/listeners/VariantOptionsConfigurerListener.java
@@ -33,7 +33,6 @@ public class VariantOptionsConfigurerListener implements JobExecutionListener {
 
     private static final Logger logger = LoggerFactory.getLogger(VariantOptionsConfigurerListener.class);
     private final boolean includeSamples;
-    private final boolean compressGenotypes;
     private final boolean calculateStats;
     private final boolean includeStats;
 
@@ -41,11 +40,9 @@ public class VariantOptionsConfigurerListener implements JobExecutionListener {
     private JobOptions jobOptions;
 
     public VariantOptionsConfigurerListener(boolean includeSamples,
-                                            boolean compressGenotypes,
                                             boolean calculateStats,
                                             boolean includeStats) {
         this.includeSamples = includeSamples;
-        this.compressGenotypes = compressGenotypes;
         this.calculateStats = calculateStats;
         this.includeStats = includeStats;
     }
@@ -53,7 +50,7 @@ public class VariantOptionsConfigurerListener implements JobExecutionListener {
     @Override
     public void beforeJob(JobExecution jobExecution) {
         logger.debug("Setting up job " + jobExecution.getJobInstance().getJobName());
-        jobOptions.configureGenotypesStorage(includeSamples, compressGenotypes);
+        jobOptions.configureGenotypesStorage(includeSamples);
         jobOptions.configureStatisticsStorage(calculateStats, includeStats);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
@@ -15,27 +15,16 @@
  */
 package uk.ac.ebi.eva.pipeline.parameters;
 
-import org.opencb.biodata.models.variant.VariantSource;
-import org.opencb.biodata.models.variant.VariantStudy;
 import org.opencb.datastore.core.ObjectMap;
 import org.opencb.opencga.lib.common.Config;
 import org.opencb.opencga.storage.core.variant.VariantStorageManager;
-import org.opencb.opencga.storage.core.variant.stats.VariantStatisticsManager;
-import org.opencb.opencga.storage.mongodb.variant.MongoDBVariantStorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.nio.file.Paths;
-import java.util.Properties;
 
 /**
  * Class to extract configuration from properties files and from command line.
@@ -48,62 +37,25 @@ import java.util.Properties;
 public class JobOptions {
     private static final Logger logger = LoggerFactory.getLogger(JobOptions.class);
 
-    public static final String VEP_INPUT = "vep.input";
-    public static final String VEP_OUTPUT = "vep.output";
-
-    // Input
-    @Value("${" + JobParametersNames.INPUT_VCF + "}") private String input;
-    @Value("${" + JobParametersNames.INPUT_VCF_ID + "}") private String fileId;
-    @Value("${" + JobParametersNames.INPUT_VCF_AGGREGATION + "}") private String aggregated;
-    @Value("${" + JobParametersNames.INPUT_STUDY_TYPE + "}") private String studyType;
-    @Value("${" + JobParametersNames.INPUT_STUDY_NAME + "}") private String studyName;
-    @Value("${" + JobParametersNames.INPUT_STUDY_ID + "}") private String studyId;
-    @Value("${" + JobParametersNames.INPUT_PEDIGREE + ":}") private String pedigree;
-    @Value("${" + JobParametersNames.INPUT_GTF + "}") private String gtf;
-
-    // Output
-    @Value("${" + JobParametersNames.OUTPUT_DIR + "}") private String outputDir;
-    @Value("${" + JobParametersNames.OUTPUT_DIR_ANNOTATION + "}") private String outputDirAnnotation;
-    @Value("${" + JobParametersNames.OUTPUT_DIR_STATISTICS + "}") private String outputDirStatistics;
-
-    @Value("${" + JobParametersNames.STATISTICS_OVERWRITE + ":false}") private boolean overwriteStats;
-
     @Value("${" + JobParametersNames.APP_OPENCGA_PATH + "}") private String opencgaAppHome;
 
     //// OpenCGA options with default values (non-customizable)
-    private String compressExtension = ".gz";
-    private boolean annotate = false;
     private VariantStorageManager.IncludeSrc includeSourceLine = VariantStorageManager.IncludeSrc.FIRST_8_COLUMNS;
-
-    /// DB connection (most parameters read from OpenCGA "conf" folder)
-    @Value("${" + JobParametersNames.CONFIG_DB_HOSTS + ":#{null}}") private String dbHosts;
-    @Value("${" + JobParametersNames.CONFIG_DB_AUTHENTICATIONDB + ":#{null}}") private String dbAuthenticationDb;
-    @Value("${" + JobParametersNames.CONFIG_DB_USER + ":#{null}}") private String dbUser;
-    @Value("${" + JobParametersNames.CONFIG_DB_PASSWORD + ":#{null}}") private String dbPassword;
-    @Value("${" + JobParametersNames.DB_NAME + ":#{null}}") private String dbName;
-    @Value("${" + JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME + ":#{null}}") private String dbCollectionVariantsName;
-    @Value("${" + JobParametersNames.DB_COLLECTIONS_FILES_NAME + ":#{null}}") private String dbCollectionFilesName;
-    @Value("${" + JobParametersNames.DB_COLLECTIONS_FEATURES_NAME +"}") private String dbCollectionGenesName;
-    @Value("${" + JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME + "}") private String dbCollectionStatsName;
-    @Value("${" + JobParametersNames.CONFIG_DB_READPREFERENCE + "}") private String readPreference;
 
     // Skip steps
     @Value("${" + JobParametersNames.ANNOTATION_SKIP + ":false}") private boolean skipAnnot;
     @Value("${" + JobParametersNames.STATISTICS_SKIP + ":false}") private boolean skipStats;
 
-    //VEP
-    @Value("${" + JobParametersNames.APP_VEP_PATH +"}") private String vepPath;
-    @Value("${" + JobParametersNames.APP_VEP_CACHE_PATH + "}") private String vepCacheDirectory;
-    @Value("${" + JobParametersNames.APP_VEP_CACHE_VERSION + "}") private String vepCacheVersion;
-    @Value("${" + JobParametersNames.APP_VEP_CACHE_SPECIES + "}") private String vepSpecies;
-    @Value("${" + JobParametersNames.INPUT_FASTA + "}") private String vepFasta;
-    @Value("${" + JobParametersNames.APP_VEP_NUMFORKS + "}") private String vepNumForks;
-
+    // Pipeline application options.
     @Value("${" + JobParametersNames.CONFIG_RESTARTABILITY_ALLOW + ":false}") private boolean allowStartIfComplete;
     @Value("${" + JobParametersNames.CONFIG_CHUNK_SIZE + ":1000}") private int chunkSize;
 
-    private ObjectMap variantOptions = new ObjectMap();
     private ObjectMap pipelineOptions = new ObjectMap();
+
+    //These values are setted through VariantOptionsConfigurerListener
+    private boolean calculateStats;
+    private boolean includeStats;
+    private boolean includeSamples;
 
     @PostConstruct
     public void loadArgs() throws IOException {
@@ -113,186 +65,49 @@ public class JobOptions {
             opencgaAppHome = System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga";
         }
         Config.setOpenCGAHome(opencgaAppHome);
-
-        loadDbConnectionOptions();
-        loadOpencgaOptions();
         loadPipelineOptions();
     }
 
-    private void loadDbConnectionOptions() throws IOException {
-        // TODO This block shall be removed when we use Spring Data parameters only
-        URI configUri = URI.create(Config.getOpenCGAHome() + "/").resolve("conf/").resolve("storage-mongodb.properties");
-        Properties properties = new Properties();
-        properties.load(new InputStreamReader(new FileInputStream(configUri.getPath())));
-
-        if (dbHosts == null) {
-            dbHosts = properties.getProperty(JobParametersNames.OPENCGA_DB_HOSTS);
-        }
-        if (dbAuthenticationDb == null) {
-            dbAuthenticationDb = properties.getProperty(JobParametersNames.OPENCGA_DB_AUTHENTICATIONDB, "");
-        }
-        if (dbUser == null) {
-            dbUser = properties.getProperty(JobParametersNames.OPENCGA_DB_USER, "");
-        }
-        if (dbPassword == null) {
-            dbPassword = properties.getProperty(JobParametersNames.OPENCGA_DB_PASSWORD, "");
-        }
-        if (dbName == null) {
-            dbName = properties.getProperty(JobParametersNames.OPENCGA_DB_NAME);
-        }
-        if (dbCollectionVariantsName == null) {
-            dbCollectionVariantsName = properties.getProperty(JobParametersNames.OPENCGA_DB_COLLECTIONS_VARIANTS_NAME, "variants");
-        }
-        if (dbCollectionFilesName == null) {
-            dbCollectionFilesName = properties.getProperty(JobParametersNames.OPENCGA_DB_COLLECTIONS_FILES_NAME, "files");
-        }
-        // TODO End of block to be removed when we use Spring Data parameters only
-
-        if (dbHosts == null || dbHosts.isEmpty()) {
-            throw new IllegalArgumentException("Please provide a database hostname");
-        }
-        if (dbName == null || dbName.isEmpty()) {
-            throw new IllegalArgumentException("Please provide a database name");
-        }
-        if (dbCollectionVariantsName == null || dbCollectionVariantsName.isEmpty()) {
-            throw new IllegalArgumentException("Please provide a name for the collection to store the variant information into");
-        }
-        if (dbCollectionFilesName == null || dbCollectionFilesName.isEmpty()) {
-            throw new IllegalArgumentException("Please provide a name for the collection to store the file information into");
-        }
-    }
-
-    private void loadOpencgaOptions() {
-        VariantSource source = new VariantSource(
-                Paths.get(input).getFileName().toString(),
-                fileId,
-                studyId,
-                studyName,
-                VariantStudy.StudyType.valueOf(studyType),
-                VariantSource.Aggregation.valueOf(aggregated));
-
-        // TODO This block shall be removed when we use Spring Data parameters only
-        variantOptions.put(VariantStorageManager.VARIANT_SOURCE, source);
-        variantOptions.put(VariantStorageManager.OVERWRITE_STATS, overwriteStats);
-        variantOptions.put(VariantStorageManager.INCLUDE_SRC, includeSourceLine);
-        variantOptions.put("compressExtension", compressExtension);
-        variantOptions.put(VariantStorageManager.ANNOTATE, annotate);
-        variantOptions.put(VariantStatisticsManager.BATCH_SIZE, chunkSize);
-
-        variantOptions.put(VariantStorageManager.DB_NAME, dbName);
-        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME, dbName);
-        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_HOSTS, dbHosts);
-        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_AUTHENTICATION_DB, dbAuthenticationDb);
-        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_USER, dbUser);
-        variantOptions.put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_PASS, dbPassword);
-        // TODO End of block to be removed when we use Spring Data parameters only
-
-        logger.debug("Using as input: {}", input);
-        logger.debug("Using as variantOptions: {}", variantOptions.entrySet().toString());
-    }
-
     private void loadPipelineOptions() {
-        pipelineOptions.put(JobParametersNames.INPUT_VCF, input);
-        pipelineOptions.put("compressExtension", compressExtension);
-        pipelineOptions.put(JobParametersNames.OUTPUT_DIR, outputDir);
-        pipelineOptions.put(JobParametersNames.OUTPUT_DIR_STATISTICS, outputDirStatistics);
-        pipelineOptions.put(JobParametersNames.INPUT_PEDIGREE, pedigree);
-        pipelineOptions.put(JobParametersNames.INPUT_GTF, gtf);
-        pipelineOptions.put(JobParametersNames.DB_NAME, dbName);
-        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, dbCollectionVariantsName);
-        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FILES_NAME, dbCollectionFilesName);
-        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME, dbCollectionGenesName);
-        pipelineOptions.put(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME, dbCollectionStatsName);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_HOSTS, dbHosts);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_AUTHENTICATIONDB, dbAuthenticationDb);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_USER, dbUser);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_PASSWORD, dbPassword);
-        pipelineOptions.put(JobParametersNames.CONFIG_DB_READPREFERENCE, readPreference);
         pipelineOptions.put(JobParametersNames.ANNOTATION_SKIP, skipAnnot);
         pipelineOptions.put(JobParametersNames.STATISTICS_SKIP, skipStats);
-
-        String annotationFilesPrefix = studyId + "_" + fileId;
-        pipelineOptions.put(VEP_INPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_variants_to_annotate.tsv").toString());
-        pipelineOptions.put(VEP_OUTPUT, URI.create(outputDirAnnotation + "/").resolve(annotationFilesPrefix + "_vep_annotation.tsv.gz").toString());
-
-        pipelineOptions.put(JobParametersNames.APP_VEP_PATH, vepPath);
-        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_PATH, vepCacheDirectory);
-        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_VERSION, vepCacheVersion);
-        pipelineOptions.put(JobParametersNames.APP_VEP_CACHE_SPECIES, vepSpecies);
-        pipelineOptions.put(JobParametersNames.INPUT_FASTA, vepFasta);
-        pipelineOptions.put(JobParametersNames.APP_VEP_NUMFORKS, vepNumForks);
-        pipelineOptions.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, allowStartIfComplete);
-        pipelineOptions.put(JobParametersNames.CONFIG_CHUNK_SIZE, chunkSize);
-
         logger.debug("Using as pipelineOptions: {}", pipelineOptions.entrySet().toString());
     }
 
-    public void configureGenotypesStorage(boolean includeSamples, boolean compressGenotypes) {
-        variantOptions.put(VariantStorageManager.INCLUDE_SAMPLES, includeSamples);
-        variantOptions.put(VariantStorageManager.COMPRESS_GENOTYPES, compressGenotypes);
+    public void configureGenotypesStorage(boolean includeSamples) {
+        this.includeSamples = includeSamples;
     }
 
     public void configureStatisticsStorage(boolean calculateStats, boolean includeStats) {
-        variantOptions.put(VariantStorageManager.CALCULATE_STATS, calculateStats);   // this is tested by hand
-        variantOptions.put(VariantStorageManager.INCLUDE_STATS, includeStats);
-    }
-
-    public ObjectMap getVariantOptions() {
-        return variantOptions;
+        this.calculateStats = calculateStats;
+        this.includeStats = includeStats;
     }
 
     public ObjectMap getPipelineOptions() {
         return pipelineOptions;
     }
 
-    public String getDbCollectionsFeaturesName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_FEATURES_NAME);
+    public boolean isAllowStartIfComplete() {
+        return allowStartIfComplete;
     }
 
-    public String getDbCollectionsVariantsName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
+    public int getChunkSize() {
+        return chunkSize;
     }
 
-    public String getDbCollectionsFilesName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_FILES_NAME);
+    public boolean isCalculateStats() {
+        return calculateStats;
     }
 
-    public String getDbCollectionsStatsName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_COLLECTIONS_STATISTICS_NAME);
+    public boolean isIncludeStats() {
+        return includeStats;
     }
 
-    public String getVepInput() {
-        return getPipelineOptions().getString(VEP_INPUT);
+    public boolean isIncludeSamples() {
+        return includeSamples;
     }
 
-    public void setVepInputFile(String vepInputFile) {
-        getPipelineOptions().put(VEP_INPUT, URI.create(vepInputFile));
-    }
-
-    public String getDbName() {
-        return getPipelineOptions().getString(JobParametersNames.DB_NAME);
-    }
-
-    public void setDbName(String dbName) {
-        this.dbName = dbName;
-        getVariantOptions().put(VariantStorageManager.DB_NAME, dbName);
-        getVariantOptions().put(MongoDBVariantStorageManager.OPENCGA_STORAGE_MONGODB_VARIANT_DB_NAME, dbName);
-        getPipelineOptions().put(JobParametersNames.DB_NAME, dbName);
-    }
-
-    public String getVepOutput() {
-        return getPipelineOptions().getString(VEP_OUTPUT);
-    }
-
-    public void setVepOutput(String vepOutput) {
-        getPipelineOptions().put(VEP_OUTPUT, URI.create(vepOutput));
-    }
-
-    public void setAppVepPath(File appVepPath) {
-        getPipelineOptions().put(JobParametersNames.APP_VEP_PATH, appVepPath);
-    }
-
-    public String getOutputDir() {
-        return getPipelineOptions().getString(JobParametersNames.OUTPUT_DIR);
+    public VariantStorageManager.IncludeSrc getIncludeSourceLine() {
+        return includeSourceLine;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
@@ -84,4 +84,7 @@ public class ParametersFromProperties {
         return properties;
     }
 
+    public String getDatabaseName() {
+        return databaseName;
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/utils/TaskletUtils.java
+++ b/src/main/java/uk/ac/ebi/eva/utils/TaskletUtils.java
@@ -11,13 +11,11 @@ import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 public class TaskletUtils {
 
     public static TaskletStep generateStep(StepBuilderFactory stepBuilderFactory, String stepName, Tasklet tasklet,
-                                           JobOptions jobOptions) {
+                                           boolean allowStartIfComplete) {
         StepBuilder step1 = stepBuilderFactory.get(stepName);
         final TaskletStepBuilder taskletBuilder = step1.tasklet(tasklet);
         // true: every job execution will do this step, even if this step is already COMPLETED
         // false(default): if the job was aborted and is relaunched, this step will NOT be done again
-        boolean allowStartIfComplete = jobOptions.getPipelineOptions().getBoolean(JobParametersNames
-                .CONFIG_RESTARTABILITY_ALLOW);
         taskletBuilder.allowStartIfComplete(allowStartIfComplete);
         return taskletBuilder.build();
     }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/ApplicationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/ApplicationTest.java
@@ -1,7 +1,5 @@
 package uk.ac.ebi.eva.pipeline;
 
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,9 +13,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
-import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
+import uk.ac.ebi.eva.pipeline.parameters.ParametersFromProperties;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 
 /**
@@ -43,14 +40,14 @@ public class ApplicationTest {
     private JobExplorer jobExplorer;
 
     @Autowired
-    private JobOptions jobOptions;
+    private ParametersFromProperties parametersFromProperties;
 
     @Rule
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Test
     public void main() throws Exception {
-        mongoRule.getTemporaryDatabase(jobOptions.getDbName());
+        mongoRule.getTemporaryDatabase(parametersFromProperties.getDatabaseName());
 
         Assert.assertEquals(EXPECTED_JOB_COUNT, jobExplorer.getJobNames().size());
         Assert.assertEquals(BeanNames.GENOTYPED_VCF_JOB, jobExplorer.getJobNames().get(0));


### PR DESCRIPTION
Removed all unused elements. 
Moved configuration variables that were in variant pipeline that were only used as boolean elements to JobOptions getters.
Moved chunk size and restartability from pipelineOptions to JobOptionsGetters.
PipelineOptions only retains the skip tests pending further refactoring.