### PR TITLE
Refactored skip parameters and removed them from jobOptions.

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobExecutionDeciderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobExecutionDeciderConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.configuration;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
+import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.ANNOTATION_SKIP_STEP_DECIDER;
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.STATISTICS_SKIP_STEP_DECIDER;
+
+@Configuration
+@EnableBatchProcessing
+public class JobExecutionDeciderConfiguration {
+
+    @Bean(ANNOTATION_SKIP_STEP_DECIDER)
+    public JobExecutionDecider annotationSkipStepDecider() {
+        return new SkipStepDecider(JobParametersNames.ANNOTATION_SKIP);
+    }
+
+    @Bean(STATISTICS_SKIP_STEP_DECIDER)
+    public JobExecutionDecider statisticsSkipStepDecider() {
+        return new SkipStepDecider(JobParametersNames.STATISTICS_SKIP);
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobExecutionDeciderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/JobExecutionDeciderConfiguration.java
@@ -26,6 +26,9 @@ import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.ANNOTATION_SKIP_STEP_DECIDER;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.STATISTICS_SKIP_STEP_DECIDER;
 
+/**
+ * This class defines the beans for the deciders to skip annotation and statistics step.
+ */
 @Configuration
 @EnableBatchProcessing
 public class JobExecutionDeciderConfiguration {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/SkipStepDecider.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/SkipStepDecider.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.deciders;
 
-import org.opencb.datastore.core.ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.JobExecution;
@@ -29,31 +28,21 @@ import org.springframework.batch.core.job.flow.JobExecutionDecider;
 public class SkipStepDecider implements JobExecutionDecider {
     private static final Logger logger = LoggerFactory.getLogger(SkipStepDecider.class);
 
-    private String skipStep;
-    private ObjectMap pipelineOptions;
-
     public static final String SKIP_STEP = "SKIP_STEP";
     public static final String DO_STEP = "DO_STEP";
 
-    /**
-     * @param pipelineOptions ObjectMap that will have a boolean for .get(skipStep), telling whether to skip or not
-     * @param skipStep        name of the key that the user sets to skip a step, e.g. "annotation.create.skip"
-     *                        It's recommended to use pre-defined constants, such as AnnotationJob.SKIP_ANNOT to avoid
-     *                        misspelling mistakes.
-     */
-    public SkipStepDecider(ObjectMap pipelineOptions, String skipStep) {
-        this.skipStep = skipStep;
-        this.pipelineOptions = pipelineOptions;
+    public final String jobParameterName;
+
+    public SkipStepDecider(String jobParameterName){
+        this.jobParameterName = jobParameterName;
     }
 
     @Override
     public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
-        if (Boolean.parseBoolean(pipelineOptions.getString(skipStep))) {
-            logger.info("Skipping step because {} is enabled", skipStep);
+        if (Boolean.parseBoolean(jobExecution.getJobParameters().getString(jobParameterName))) {
+            logger.info("Step skipped due to setting {} enabled", jobParameterName);
             return new FlowExecutionStatus(SKIP_STEP);
         }
-
-        logger.info("Running step because {} is disabled", skipStep);
         return new FlowExecutionStatus(DO_STEP);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/SkipStepDecider.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/deciders/SkipStepDecider.java
@@ -33,14 +33,14 @@ public class SkipStepDecider implements JobExecutionDecider {
 
     public final String jobParameterName;
 
-    public SkipStepDecider(String jobParameterName){
+    public SkipStepDecider(String jobParameterName) {
         this.jobParameterName = jobParameterName;
     }
 
     @Override
     public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
         if (Boolean.parseBoolean(jobExecution.getJobParameters().getString(jobParameterName))) {
-            logger.info("Step skipped due to setting {} enabled", jobParameterName);
+            logger.info("Step skipped due to {} enabled", jobParameterName);
             return new FlowExecutionStatus(SKIP_STEP);
         }
         return new FlowExecutionStatus(DO_STEP);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlowOptional.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/flows/AnnotationFlowOptional.java
@@ -19,15 +19,15 @@ import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.job.builder.FlowBuilder;
 import org.springframework.batch.core.job.flow.Flow;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Scope;
+import uk.ac.ebi.eva.pipeline.configuration.JobExecutionDeciderConfiguration;
 import uk.ac.ebi.eva.pipeline.jobs.deciders.SkipStepDecider;
-import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.ANNOTATION_SKIP_STEP_DECIDER;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_FLOW;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_OPTIONAL_FLOW;
 
@@ -39,24 +39,18 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_OPTI
  */
 @Configuration
 @EnableBatchProcessing
-@Import({AnnotationFlow.class})
+@Import({AnnotationFlow.class, JobExecutionDeciderConfiguration.class})
 public class AnnotationFlowOptional {
 
     @Bean(VEP_ANNOTATION_OPTIONAL_FLOW)
-    Flow vepAnnotationOptionalFlow(@Qualifier(VEP_ANNOTATION_FLOW) Flow vepAnnotationFlow,
-                                   SkipStepDecider skipStepDecider) {
+    public Flow vepAnnotationOptionalFlow(@Qualifier(VEP_ANNOTATION_FLOW) Flow vepAnnotationFlow,
+                                   @Qualifier(ANNOTATION_SKIP_STEP_DECIDER) JobExecutionDecider decider) {
         return new FlowBuilder<Flow>(VEP_ANNOTATION_OPTIONAL_FLOW)
-                .start(skipStepDecider).on(SkipStepDecider.DO_STEP)
+                .start(decider).on(SkipStepDecider.DO_STEP)
                 .to(vepAnnotationFlow)
-                .from(skipStepDecider).on(SkipStepDecider.SKIP_STEP)
+                .from(decider).on(SkipStepDecider.SKIP_STEP)
                 .end(BatchStatus.COMPLETED.toString())
                 .build();
-    }
-
-    @Bean
-    @Scope("prototype")
-    SkipStepDecider skipStepDecider(JobOptions jobOptions) {
-        return new SkipStepDecider(jobOptions.getPipelineOptions(), JobParametersNames.ANNOTATION_SKIP);
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobOptions.java
@@ -42,15 +42,9 @@ public class JobOptions {
     //// OpenCGA options with default values (non-customizable)
     private VariantStorageManager.IncludeSrc includeSourceLine = VariantStorageManager.IncludeSrc.FIRST_8_COLUMNS;
 
-    // Skip steps
-    @Value("${" + JobParametersNames.ANNOTATION_SKIP + ":false}") private boolean skipAnnot;
-    @Value("${" + JobParametersNames.STATISTICS_SKIP + ":false}") private boolean skipStats;
-
     // Pipeline application options.
     @Value("${" + JobParametersNames.CONFIG_RESTARTABILITY_ALLOW + ":false}") private boolean allowStartIfComplete;
     @Value("${" + JobParametersNames.CONFIG_CHUNK_SIZE + ":1000}") private int chunkSize;
-
-    private ObjectMap pipelineOptions = new ObjectMap();
 
     //These values are setted through VariantOptionsConfigurerListener
     private boolean calculateStats;
@@ -65,13 +59,6 @@ public class JobOptions {
             opencgaAppHome = System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga";
         }
         Config.setOpenCGAHome(opencgaAppHome);
-        loadPipelineOptions();
-    }
-
-    private void loadPipelineOptions() {
-        pipelineOptions.put(JobParametersNames.ANNOTATION_SKIP, skipAnnot);
-        pipelineOptions.put(JobParametersNames.STATISTICS_SKIP, skipStats);
-        logger.debug("Using as pipelineOptions: {}", pipelineOptions.entrySet().toString());
     }
 
     public void configureGenotypesStorage(boolean includeSamples) {
@@ -81,10 +68,6 @@ public class JobOptions {
     public void configureStatisticsStorage(boolean calculateStats, boolean includeStats) {
         this.calculateStats = calculateStats;
         this.includeStats = includeStats;
-    }
-
-    public ObjectMap getPipelineOptions() {
-        return pipelineOptions;
     }
 
     public boolean isAllowStartIfComplete() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/ParametersFromProperties.java
@@ -62,6 +62,12 @@ public class ParametersFromProperties {
     @Value(PROPERTY + JobParametersNames.OUTPUT_DIR_STATISTICS + OR_NULL)
     private String outputDirStats;
 
+    @Value(PROPERTY + JobParametersNames.STATISTICS_SKIP + OR_NULL)
+    private String statisticsSkip;
+
+    @Value(PROPERTY + JobParametersNames.ANNOTATION_SKIP + OR_NULL)
+    private String annotationSkip;
+
     public Properties getProperties() {
         Properties properties = new Properties();
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -96,6 +96,7 @@ public class AggregatedVcfJobTest {
                 .inputVcfId("1")
                 .collectionFilesName("files")
                 .timestamp()
+                .annotationSkip(true)
                 .toJobParameters();
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -30,11 +30,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
 import uk.ac.ebi.eva.pipeline.Application;
 import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
-import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
@@ -52,17 +50,16 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResource;
 
 /**
  * Workflow test for {@link GenotypedVcfJob}
- *
+ * <p>
  * TODO The test should fail when we will integrate the JobParameter validation since there are empty parameters for VEP
  */
 @RunWith(SpringRunner.class)
-@ActiveProfiles({Application.VARIANT_WRITER_MONGO_PROFILE,Application.VARIANT_ANNOTATION_MONGO_PROFILE})
+@ActiveProfiles({Application.VARIANT_WRITER_MONGO_PROFILE, Application.VARIANT_ANNOTATION_MONGO_PROFILE})
 @TestPropertySource({"classpath:genotyped-vcf-workflow.properties", "classpath:test-mongo.properties"})
 @ContextConfiguration(classes = {GenotypedVcfJob.class, BatchTestConfiguration.class})
 public class GenotypedVcfJobWorkflowTest {
@@ -94,11 +91,12 @@ public class GenotypedVcfJobWorkflowTest {
 
     public static final Set<String> EXPECTED_ANNOTATION_STEP_NAMES = new TreeSet<>(
             Arrays.asList(BeanNames.GENERATE_VEP_INPUT_STEP, BeanNames.GENERATE_VEP_ANNOTATION_STEP,
-                          BeanNames.LOAD_VEP_ANNOTATION_STEP));
+                    BeanNames.LOAD_VEP_ANNOTATION_STEP));
 
     @Test
     public void allStepsShouldBeExecuted() throws Exception {
-        JobParameters jobParameters = initVariantConfigurationJob();
+        EvaJobParameterBuilder builder = initVariantConfigurationJob();
+        JobParameters jobParameters = builder.toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
 
@@ -134,25 +132,23 @@ public class GenotypedVcfJobWorkflowTest {
 
     @Test
     public void optionalStepsShouldBeSkipped() throws Exception {
-        JobParameters jobParameters = initVariantConfigurationJob();
-
-        jobOptions.getPipelineOptions().put(JobParametersNames.ANNOTATION_SKIP, true);
-        jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, true);
+        EvaJobParameterBuilder builder = initVariantConfigurationJob();
+        JobParameters jobParameters = builder.annotationSkip(true).statisticsSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
 
         assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
 
         Set<String> names = execution.getStepExecutions().stream().map(StepExecution::getStepName)
-                                      .collect(Collectors.toSet());
+                .collect(Collectors.toSet());
 
         assertEquals(EXPECTED_REQUIRED_STEP_NAMES, names);
     }
 
     @Test
     public void statsStepsShouldBeSkipped() throws Exception {
-        JobParameters jobParameters = initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, true);
+        EvaJobParameterBuilder builder = initVariantConfigurationJob();
+        JobParameters jobParameters = builder.statisticsSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
 
@@ -183,8 +179,8 @@ public class GenotypedVcfJobWorkflowTest {
 
     @Test
     public void annotationStepsShouldBeSkipped() throws Exception {
-        JobParameters jobParameters = initVariantConfigurationJob();
-        jobOptions.getPipelineOptions().put(JobParametersNames.ANNOTATION_SKIP, true);
+        EvaJobParameterBuilder builder = initVariantConfigurationJob();
+        JobParameters jobParameters = builder.annotationSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
 
@@ -213,7 +209,7 @@ public class GenotypedVcfJobWorkflowTest {
                 .before(nameToStepExecution.get(BeanNames.LOAD_STATISTICS_STEP).getStartTime()));
     }
 
-    private JobParameters initVariantConfigurationJob() throws IOException {
+    private EvaJobParameterBuilder initVariantConfigurationJob() throws IOException {
         Config.setOpenCGAHome(opencgaHome);
         File inputFile = getResource(INPUT_FILE);
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
@@ -236,11 +232,11 @@ public class GenotypedVcfJobWorkflowTest {
                 .vepCacheSpecies("")
                 .vepCacheVersion("")
                 .vepNumForks("")
-                .vepPath(getResource(MOCK_VEP).getPath());
+                .vepPath(getResource(MOCK_VEP).getPath())
+                .annotationSkip(false)
+                .statisticsSkip(false);
 
-        jobOptions.getPipelineOptions().put(JobParametersNames.ANNOTATION_SKIP, false);
-        jobOptions.getPipelineOptions().put(JobParametersNames.STATISTICS_SKIP, false);
-        return evaJobParameterBuilder.toJobParameters();
+        return evaJobParameterBuilder;
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -232,9 +232,7 @@ public class GenotypedVcfJobWorkflowTest {
                 .vepCacheSpecies("")
                 .vepCacheVersion("")
                 .vepNumForks("")
-                .vepPath(getResource(MOCK_VEP).getPath())
-                .annotationSkip(false)
-                .statisticsSkip(false);
+                .vepPath(getResource(MOCK_VEP).getPath());
 
         return evaJobParameterBuilder;
     }

--- a/src/test/java/uk/ac/ebi/eva/utils/EvaJobParameterBuilder.java
+++ b/src/test/java/uk/ac/ebi/eva/utils/EvaJobParameterBuilder.java
@@ -108,4 +108,14 @@ public class EvaJobParameterBuilder extends JobParametersBuilder {
         addParameter(JobParametersNames.OUTPUT_DIR_STATISTICS, new JobParameter(outputDirStats));
         return this;
     }
+
+    public EvaJobParameterBuilder annotationSkip(boolean annotationSkip) {
+        addParameter(JobParametersNames.ANNOTATION_SKIP, new JobParameter(Boolean.toString(annotationSkip)));
+        return this;
+    }
+
+    public EvaJobParameterBuilder statisticsSkip(boolean statisticsSkip) {
+        addParameter(JobParametersNames.STATISTICS_SKIP, new JobParameter(Boolean.toString(statisticsSkip)));
+        return this;
+    }
 }


### PR DESCRIPTION
SkipStepDecider now receives a jobParameterName that is queried to decide if it has to skip the next step. This is done without @StepScopes or @JobScopes as it seems this class was being executed by a thread without the bean scope. Thus we use the JobExecution that the system passes in the decide function to retrieve the value of the parameter.