### PR TITLE
EVA-705 Modify NonAnnotatedVariantsReader to return java objects instead of DBObject

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
+import uk.ac.ebi.eva.pipeline.parameters.AnnotationParameters;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 import uk.ac.ebi.eva.pipeline.parameters.InputParameters;
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
-import uk.ac.ebi.eva.pipeline.parameters.AnnotationParameters;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 import uk.ac.ebi.eva.pipeline.parameters.InputParameters;
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -23,9 +23,6 @@ import org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantConverter;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
-import org.springframework.batch.item.NonTransientResourceException;
-import org.springframework.batch.item.ParseException;
-import org.springframework.batch.item.UnexpectedInputException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.mongodb.core.MongoOperations;
 
@@ -90,8 +87,7 @@ public class NonAnnotatedVariantsMongoReader implements ItemStreamReader<Variant
     }
 
     @Override
-    public VariantWrapper read()
-            throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+    public VariantWrapper read() throws Exception {
         DBObject dbObject = delegateReader.read();
         if (dbObject != null) {
             Variant variant = converter.convertToDataModelType(dbObject);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -18,10 +18,16 @@ package uk.ac.ebi.eva.pipeline.io.readers;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
+import org.opencb.biodata.models.variant.Variant;
+import org.opencb.opencga.storage.mongodb.variant.DBObjectToVariantConverter;
+import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.util.ClassUtils;
 
 import uk.ac.ebi.eva.commons.models.converters.data.VariantSourceEntryToDBObjectConverter;
 import uk.ac.ebi.eva.commons.models.converters.data.VariantToDBObjectConverter;
+import uk.ac.ebi.eva.pipeline.model.VariantWrapper;
 
 import javax.annotation.PostConstruct;
 
@@ -31,39 +37,69 @@ import javax.annotation.PostConstruct;
  * {@link org.springframework.batch.item.data.MongoItemReader} is using
  * pagination and it is slow with large collections
  */
-public class NonAnnotatedVariantsMongoReader extends MongoDbCursorItemReader {
+public class NonAnnotatedVariantsMongoReader extends AbstractItemCountingItemStreamItemReader<VariantWrapper>
+        implements InitializingBean {
+
+    private MongoDbCursorItemReader delegateReader;
+
+    private DBObjectToVariantConverter converter;
 
     private static final String STUDY_KEY = VariantToDBObjectConverter.FILES_FIELD + "."
             + VariantSourceEntryToDBObjectConverter.STUDYID_FIELD;
 
     /**
-     * @param studyId Can be the empty string, meaning to bring all non-annotated variants in the collection.
-     *  If the studyId string is not empty, bring only non-annotated variants from that study. This parameter should
-     *  not be null in any case.
+     * @param studyId Can be the empty string, meaning to bring all non-annotated variants in the collection. If the
+     * studyId string is not empty, bring only non-annotated variants from that study. This parameter should not be null
+     * in any case.
      */
     public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId) {
+        setName(ClassUtils.getShortName(NonAnnotatedVariantsMongoReader.class));
         if (studyId == null) {
             throw new IllegalArgumentException("NonAnnotatedVariantsMongoReader needs a non-null studyId " +
                     "(it can take a studyId or an empty string for reading every study)");
         }
 
-        setTemplate(template);
-        setCollection(collectionsVariantsName);
+        delegateReader = new MongoDbCursorItemReader();
+        delegateReader.setTemplate(template);
+        delegateReader.setCollection(collectionsVariantsName);
 
         BasicDBObjectBuilder queryBuilder = BasicDBObjectBuilder.start();
         if (!studyId.isEmpty()) {
             queryBuilder.add(STUDY_KEY, studyId);
         }
         DBObject query = queryBuilder.add("annot.ct.so", new BasicDBObject("$exists", false)).get();
-        setQuery(query);
+        delegateReader.setQuery(query);
 
-        String[] fields = { "chr", "start", "end", "ref", "alt" };
-        setFields(fields);
+        String[] fields = {"chr", "start", "end", "ref", "alt"};
+        delegateReader.setFields(fields);
+
+        converter = new DBObjectToVariantConverter();
     }
 
     @PostConstruct
     @Override
     public void afterPropertiesSet() throws Exception {
-        super.afterPropertiesSet();
+        delegateReader.afterPropertiesSet();
+    }
+
+    @Override
+    protected VariantWrapper doRead() throws Exception {
+        DBObject dbObject = delegateReader.doRead();
+        if (dbObject != null) {
+            Variant variant = converter.convertToDataModelType(dbObject);
+            return new VariantWrapper(variant);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    protected void doOpen() throws Exception {
+        delegateReader.doOpen();
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        delegateReader.doClose();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -48,22 +48,16 @@ public class NonAnnotatedVariantsMongoReader implements ItemStreamReader<Variant
             + VariantSourceEntryToDBObjectConverter.STUDYID_FIELD;
 
     /**
-     * @param studyId Can be the empty string, meaning to bring all non-annotated variants in the collection. If the
-     * studyId string is not empty, bring only non-annotated variants from that study. This parameter should not be null
-     * in any case.
+     * @param studyId Can be the empty string or null, meaning to bring all non-annotated variants in the collection.
+     * If the studyId string is not empty, bring only non-annotated variants from that study.
      */
     public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId) {
-        if (studyId == null) {
-            throw new IllegalArgumentException("NonAnnotatedVariantsMongoReader needs a non-null studyId " +
-                    "(it can take a studyId or an empty string for reading every study)");
-        }
-
         delegateReader = new MongoDbCursorItemReader();
         delegateReader.setTemplate(template);
         delegateReader.setCollection(collectionsVariantsName);
 
         BasicDBObjectBuilder queryBuilder = BasicDBObjectBuilder.start();
-        if (!studyId.isEmpty()) {
+        if (studyId != null && !studyId.isEmpty()) {
             queryBuilder.add(STUDY_KEY, studyId);
         }
         DBObject query = queryBuilder.add("annot.ct.so", new BasicDBObject("$exists", false)).get();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/VepInputGeneratorStep.java
@@ -15,12 +15,12 @@
  */
 package uk.ac.ebi.eva.pipeline.jobs.steps;
 
-import com.mongodb.DBObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,12 +28,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
 import uk.ac.ebi.eva.pipeline.configuration.ChunkSizeCompletionPolicyConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.readers.NonAnnotatedVariantsMongoReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VepInputFlatFileWriterConfiguration;
-import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.io.writers.VepInputFlatFileWriter;
-import uk.ac.ebi.eva.pipeline.jobs.steps.processors.AnnotationProcessor;
 import uk.ac.ebi.eva.pipeline.model.VariantWrapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 
@@ -66,7 +65,7 @@ public class VepInputGeneratorStep {
 
     @Autowired
     @Qualifier(NON_ANNOTATED_VARIANTS_READER)
-    private NonAnnotatedVariantsMongoReader reader;
+    private ItemStreamReader<VariantWrapper> reader;
 
     @Autowired
     @Qualifier(VEP_INPUT_WRITER)
@@ -78,9 +77,8 @@ public class VepInputGeneratorStep {
         logger.debug("Building '" + GENERATE_VEP_INPUT_STEP + "'");
 
         return stepBuilderFactory.get(GENERATE_VEP_INPUT_STEP)
-                .<DBObject, VariantWrapper>chunk(chunkSizeCompletionPolicy)
+                .<VariantWrapper, VariantWrapper>chunk(chunkSizeCompletionPolicy)
                 .reader(reader)
-                .processor(new AnnotationProcessor())
                 .writer(writer)
                 .allowStartIfComplete(jobOptions.isAllowStartIfComplete())
                 .build();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
@@ -42,7 +42,7 @@ public class AnnotationParameters {
     @Value(PARAMETER + JobParametersNames.INPUT_STUDY_ID + OR_EMPTY)
     private String studyId;
 
-    @Value(PARAMETER + JobParametersNames.INPUT_VCF_ID + END)
+    @Value(PARAMETER + JobParametersNames.INPUT_VCF_ID + OR_EMPTY)
     private String fileId;
 
     @Value(PARAMETER + JobParametersNames.APP_VEP_PATH + END)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
@@ -34,11 +34,12 @@ import uk.ac.ebi.eva.utils.URLHelper;
 public class AnnotationParameters {
     private static final String PARAMETER = "#{jobParameters['";
     private static final String END = "']}";
+    private static final String OR_EMPTY = "']?:''}";
 
     @Value(PARAMETER + JobParametersNames.OUTPUT_DIR_ANNOTATION + END)
     private String outputDirAnnotation;
 
-    @Value(PARAMETER + JobParametersNames.INPUT_STUDY_ID + END)
+    @Value(PARAMETER + JobParametersNames.INPUT_STUDY_ID + OR_EMPTY)
     private String studyId;
 
     @Value(PARAMETER + JobParametersNames.INPUT_VCF_ID + END)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/InputParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/InputParameters.java
@@ -31,11 +31,12 @@ public class InputParameters {
     private static final String PARAMETER = "#{jobParameters['";
     private static final String END = "']}";
     private static final String OR_NULL = "']?:null}";
+    private static final String OR_EMPTY = "']?:''}";
 
     @Value(PARAMETER + JobParametersNames.INPUT_STUDY_ID + END)
     private String studyId;
 
-    @Value(PARAMETER + JobParametersNames.INPUT_VCF_ID + END)
+    @Value(PARAMETER + JobParametersNames.INPUT_VCF_ID + OR_EMPTY)
     private String vcfId;
 
     @Value(PARAMETER + JobParametersNames.INPUT_VCF + END)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
@@ -54,7 +54,7 @@ public class AggregatedVcfJobParametersValidator extends DefaultJobParametersVal
 
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
             jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator(studyIdRequired));
-            jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());
+            jobParametersValidators.add(new AnnotationLoaderStepParametersValidator(studyIdRequired));
             jobParametersValidators.add(new AnnotationMetadataStepParametersValidator());
         }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
@@ -22,6 +22,7 @@ import org.springframework.batch.core.job.CompositeJobParametersValidator;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationLoaderStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationMetadataStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.FileLoaderStepParametersValidator;
@@ -50,6 +51,9 @@ public class AggregatedVcfJobParametersValidator extends DefaultJobParametersVal
 
         Boolean skipAnnotation = Boolean.valueOf(jobParameters.getString(JobParametersNames.ANNOTATION_SKIP));
         if (!skipAnnotation) {
+            // the next validator is required only in some jobs that use the annotation steps, the steps don't include it
+            jobParametersValidators.add(new InputStudyIdValidator());
+
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
             jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator());
             jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AggregatedVcfJobParametersValidator.java
@@ -22,7 +22,6 @@ import org.springframework.batch.core.job.CompositeJobParametersValidator;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
-import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationLoaderStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationMetadataStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.FileLoaderStepParametersValidator;
@@ -51,11 +50,10 @@ public class AggregatedVcfJobParametersValidator extends DefaultJobParametersVal
 
         Boolean skipAnnotation = Boolean.valueOf(jobParameters.getString(JobParametersNames.ANNOTATION_SKIP));
         if (!skipAnnotation) {
-            // the next validator is required only in some jobs that use the annotation steps, the steps don't include it
-            jobParametersValidators.add(new InputStudyIdValidator());
+            boolean studyIdRequired = true;
 
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
-            jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator());
+            jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator(studyIdRequired));
             jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());
             jobParametersValidators.add(new AnnotationMetadataStepParametersValidator());
         }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
@@ -22,6 +22,7 @@ import org.springframework.batch.core.job.CompositeJobParametersValidator;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationLoaderStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationMetadataStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.FileLoaderStepParametersValidator;
@@ -52,6 +53,8 @@ public class GenotypedVcfJobParametersValidator extends DefaultJobParametersVali
 
         Boolean skipAnnotation = Boolean.valueOf(jobParameters.getString(JobParametersNames.ANNOTATION_SKIP));
         if (!skipAnnotation) {
+            jobParametersValidators.add(new InputStudyIdValidator());
+
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
             jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator());
             jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
@@ -22,7 +22,6 @@ import org.springframework.batch.core.job.CompositeJobParametersValidator;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
-import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationLoaderStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationMetadataStepParametersValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.step.FileLoaderStepParametersValidator;
@@ -53,11 +52,10 @@ public class GenotypedVcfJobParametersValidator extends DefaultJobParametersVali
 
         Boolean skipAnnotation = Boolean.valueOf(jobParameters.getString(JobParametersNames.ANNOTATION_SKIP));
         if (!skipAnnotation) {
-            // the next validator is required only in some jobs that use the annotation steps, the steps don't include it
-            jobParametersValidators.add(new InputStudyIdValidator());
+            boolean studyIdRequired = true;
 
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
-            jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator());
+            jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator(studyIdRequired));
             jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());
             jobParametersValidators.add(new AnnotationMetadataStepParametersValidator());
         }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
@@ -53,6 +53,7 @@ public class GenotypedVcfJobParametersValidator extends DefaultJobParametersVali
 
         Boolean skipAnnotation = Boolean.valueOf(jobParameters.getString(JobParametersNames.ANNOTATION_SKIP));
         if (!skipAnnotation) {
+            // the next validator is required only in some jobs that use the annotation steps, the steps don't include it
             jobParametersValidators.add(new InputStudyIdValidator());
 
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidator.java
@@ -56,7 +56,7 @@ public class GenotypedVcfJobParametersValidator extends DefaultJobParametersVali
 
             jobParametersValidators.add(new VepInputGeneratorStepParametersValidator());
             jobParametersValidators.add(new VepAnnotationGeneratorStepParametersValidator(studyIdRequired));
-            jobParametersValidators.add(new AnnotationLoaderStepParametersValidator());
+            jobParametersValidators.add(new AnnotationLoaderStepParametersValidator(studyIdRequired));
             jobParametersValidators.add(new AnnotationMetadataStepParametersValidator());
         }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidator.java
@@ -35,6 +35,7 @@ import uk.ac.ebi.eva.pipeline.parameters.validation.VepPathValidator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -54,7 +55,6 @@ public class VepAnnotationGeneratorStepParametersValidator extends DefaultJobPar
                            JobParametersNames.APP_VEP_NUMFORKS,
                            JobParametersNames.APP_VEP_PATH,
                            JobParametersNames.INPUT_FASTA,
-                           JobParametersNames.INPUT_VCF_ID,
                            JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
         this.isStudyIdRequired = isStudyIdRequired;
@@ -67,19 +67,20 @@ public class VepAnnotationGeneratorStepParametersValidator extends DefaultJobPar
     }
 
     private CompositeJobParametersValidator compositeJobParametersValidator() {
-        List<JobParametersValidator> jobParametersValidators = new ArrayList<>(Arrays.asList(
+        List<JobParametersValidator> jobParametersValidators = new ArrayList<>();
+        Collections.addAll(jobParametersValidators,
                 new VepPathValidator(),
                 new VepCacheVersionValidator(),
                 new VepCachePathValidator(),
                 new VepCacheSpeciesValidator(),
                 new InputFastaValidator(),
                 new VepNumForksValidator(),
-                new OutputDirAnnotationValidator(),
-                new InputVcfIdValidator()
-        ));
+                new OutputDirAnnotationValidator()
+        );
 
         if (isStudyIdRequired) {
             jobParametersValidators.add(new InputStudyIdValidator());
+            jobParametersValidators.add(new InputVcfIdValidator());
         }
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidator.java
@@ -33,6 +33,7 @@ import uk.ac.ebi.eva.pipeline.parameters.validation.VepCacheVersionValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.VepNumForksValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.VepPathValidator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -44,17 +45,19 @@ import java.util.List;
  */
 public class VepAnnotationGeneratorStepParametersValidator extends DefaultJobParametersValidator {
 
-    public VepAnnotationGeneratorStepParametersValidator() {
+    private boolean isStudyIdRequired;
+
+    public VepAnnotationGeneratorStepParametersValidator(boolean isStudyIdRequired) {
         super(new String[]{JobParametersNames.APP_VEP_CACHE_PATH,
                            JobParametersNames.APP_VEP_CACHE_SPECIES,
                            JobParametersNames.APP_VEP_CACHE_VERSION,
                            JobParametersNames.APP_VEP_NUMFORKS,
                            JobParametersNames.APP_VEP_PATH,
                            JobParametersNames.INPUT_FASTA,
-                           JobParametersNames.INPUT_STUDY_ID,
                            JobParametersNames.INPUT_VCF_ID,
                            JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
+        this.isStudyIdRequired = isStudyIdRequired;
     }
 
     @Override
@@ -64,7 +67,7 @@ public class VepAnnotationGeneratorStepParametersValidator extends DefaultJobPar
     }
 
     private CompositeJobParametersValidator compositeJobParametersValidator() {
-        final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
+        List<JobParametersValidator> jobParametersValidators = new ArrayList<>(Arrays.asList(
                 new VepPathValidator(),
                 new VepCacheVersionValidator(),
                 new VepCachePathValidator(),
@@ -72,9 +75,12 @@ public class VepAnnotationGeneratorStepParametersValidator extends DefaultJobPar
                 new InputFastaValidator(),
                 new VepNumForksValidator(),
                 new OutputDirAnnotationValidator(),
-                new InputStudyIdValidator(),
                 new InputVcfIdValidator()
-        );
+        ));
+
+        if (isStudyIdRequired) {
+            jobParametersValidators.add(new InputStudyIdValidator());
+        }
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();
         compositeJobParametersValidator.setValidators(jobParametersValidators);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
@@ -26,7 +26,6 @@ import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigRestartabilityAllowValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
-import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.InputVcfIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OptionalValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OutputDirAnnotationValidator;
@@ -45,7 +44,6 @@ public class VepInputGeneratorStepParametersValidator extends DefaultJobParamete
     public VepInputGeneratorStepParametersValidator() {
         super(new String[]{JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
                            JobParametersNames.DB_NAME,
-                           JobParametersNames.INPUT_STUDY_ID,
                            JobParametersNames.INPUT_VCF_ID,
                            JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
@@ -61,7 +59,6 @@ public class VepInputGeneratorStepParametersValidator extends DefaultJobParamete
         final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
                 new DbCollectionsVariantsNameValidator(),
                 new DbNameValidator(),
-                new InputStudyIdValidator(),
                 new InputVcfIdValidator(),
                 new OutputDirAnnotationValidator(),
                 new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE),

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidator.java
@@ -30,14 +30,12 @@ import uk.ac.ebi.eva.pipeline.parameters.validation.InputVcfIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OptionalValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OutputDirAnnotationValidator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * Validates the job parameters necessary to execute a {@link uk.ac.ebi.eva.pipeline.jobs.steps.VepInputGeneratorStep}
- * <p>
- * The parameters OUTPUT_DIR_ANNOTATION, INPUT_STUDY_ID and INPUT_VCF_ID are used to build the VEP input option
- * {@see uk.ac.ebi.eva.pipeline.configuration.JobOptions#loadPipelineOptions()}
  */
 public class VepInputGeneratorStepParametersValidator extends DefaultJobParametersValidator {
 
@@ -56,14 +54,14 @@ public class VepInputGeneratorStepParametersValidator extends DefaultJobParamete
     }
 
     private CompositeJobParametersValidator compositeJobParametersValidator() {
-        final List<JobParametersValidator> jobParametersValidators = Arrays.asList(
+        final List<JobParametersValidator> jobParametersValidators = new ArrayList<>(Arrays.asList(
                 new DbCollectionsVariantsNameValidator(),
                 new DbNameValidator(),
                 new InputVcfIdValidator(),
                 new OutputDirAnnotationValidator(),
                 new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE),
                 new OptionalValidator(new ConfigRestartabilityAllowValidator(), JobParametersNames.CONFIG_RESTARTABILITY_ALLOW)
-        );
+        ));
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();
         compositeJobParametersValidator.setValidators(jobParametersValidators);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -81,12 +81,11 @@ public class NonAnnotatedVariantsMongoReaderTest {
     }
 
     @Test
-    public void shouldReadVariantsWithoutAnnotationField() throws Exception {
+    public void shouldReadVariantsWithoutAnnotationFieldInAllStudies() throws Exception {
         checkNonAnnotatedVariantsRead(EXPECTED_NON_ANNOTATED_VARIANTS_IN_DB, ALL_STUDIES);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testStudyIdIsRequired() throws Exception {
+    public void shouldReadVariantsWithoutAnnotationFieldInAllStudiesUsingNull() throws Exception {
         checkNonAnnotatedVariantsRead(EXPECTED_NON_ANNOTATED_VARIANTS_IN_DB, null);
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -108,7 +109,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
         while ((variantWrapper = mongoItemReader.read()) != null) {
             itemCount++;
             assertFalse(variantWrapper.getChr().isEmpty());
-            assertFalse(variantWrapper.getStart() == 0);
+            assertNotEquals(0, variantWrapper.getStart());
 
             Field privateVariantField = VariantWrapper.class.getDeclaredField("variant");
             privateVariantField.setAccessible(true);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -15,11 +15,11 @@
  */
 package uk.ac.ebi.eva.pipeline.io.readers;
 
-import com.mongodb.DBObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.core.JobParametersInvalidException;
+import org.opencb.biodata.models.variant.Variant;
+import org.opencb.biodata.models.variant.annotation.VariantAnnotation;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,18 +30,19 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import uk.ac.ebi.eva.commons.models.converters.data.VariantToDBObjectConverter;
 import uk.ac.ebi.eva.pipeline.Application;
 import uk.ac.ebi.eva.pipeline.configuration.MongoConfiguration;
+import uk.ac.ebi.eva.pipeline.model.VariantWrapper;
 import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 /**
  * {@link NonAnnotatedVariantsMongoReader}
@@ -103,12 +104,16 @@ public class NonAnnotatedVariantsMongoReaderTest {
         mongoItemReader.open(executionContext);
 
         int itemCount = 0;
-        DBObject variantMongoDocument;
-        while ((variantMongoDocument = mongoItemReader.read()) != null) {
+        VariantWrapper variantWrapper;
+        while ((variantWrapper = mongoItemReader.read()) != null) {
             itemCount++;
-            assertTrue(variantMongoDocument.containsField(VariantToDBObjectConverter.CHROMOSOME_FIELD));
-            assertTrue(variantMongoDocument.containsField(VariantToDBObjectConverter.START_FIELD));
-            assertFalse(variantMongoDocument.containsField(VariantToDBObjectConverter.ANNOTATION_FIELD));
+            assertFalse(variantWrapper.getChr().isEmpty());
+            assertFalse(variantWrapper.getStart() == 0);
+
+            Field privateVariantField = VariantWrapper.class.getDeclaredField("variant");
+            privateVariantField.setAccessible(true);
+            VariantAnnotation annotation = ((Variant) privateVariantField.get(variantWrapper)).getAnnotation();
+            assertNull(annotation.getConsequenceTypes());
         }
         assertEquals(expectedNonAnnotatedVariants, itemCount);
         mongoItemReader.close();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationLoaderStepParametersValidatorTest.java
@@ -45,7 +45,8 @@ public class AnnotationLoaderStepParametersValidatorTest {
 
     @Before
     public void setUp() throws Exception {
-        validator = new AnnotationLoaderStepParametersValidator();
+        boolean studyIdRequired = true;
+        validator = new AnnotationLoaderStepParametersValidator(studyIdRequired);
         final String dir = temporaryFolder.getRoot().getCanonicalPath();
 
         requiredParameters = new TreeMap<>();
@@ -98,9 +99,27 @@ public class AnnotationLoaderStepParametersValidatorTest {
         validator.validate(new JobParameters(requiredParameters));
     }
 
+    @Test
+    public void inputVcfIdIsNotRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_VCF_ID);
+
+        boolean studyIdNotRequired = false;
+        validator = new AnnotationLoaderStepParametersValidator(studyIdNotRequired);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
     @Test(expected = JobParametersInvalidException.class)
     public void inputStudyIdIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test
+    public void inputStudyIdIsNotRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
+
+        boolean studyIdNotRequired = false;
+        validator = new AnnotationLoaderStepParametersValidator(studyIdNotRequired);
         validator.validate(new JobParameters(requiredParameters));
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidatorTest.java
@@ -127,6 +127,15 @@ public class VepAnnotationGeneratorStepParametersValidatorTest {
         validator.validate(new JobParameters(requiredParameters));
     }
 
+    @Test
+    public void inputVcfIdIsNotRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_VCF_ID);
+
+        boolean studyIdNotRequired = false;
+        validator = new VepAnnotationGeneratorStepParametersValidator(studyIdNotRequired);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
     @Test(expected = JobParametersInvalidException.class)
     public void outputDirAnnotationIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.OUTPUT_DIR_ANNOTATION);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepAnnotationGeneratorStepParametersValidatorTest.java
@@ -45,7 +45,8 @@ public class VepAnnotationGeneratorStepParametersValidatorTest {
 
     @Before
     public void setUp() throws IOException {
-        validator = new VepAnnotationGeneratorStepParametersValidator();
+        boolean studyIdRequired = true;
+        validator = new VepAnnotationGeneratorStepParametersValidator(studyIdRequired);
 
         requiredParameters = new TreeMap<>();
         requiredParameters.put(JobParametersNames.APP_VEP_CACHE_PATH,
@@ -108,6 +109,15 @@ public class VepAnnotationGeneratorStepParametersValidatorTest {
     @Test(expected = JobParametersInvalidException.class)
     public void inputStudyIdIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test
+    public void inputStudyIdIsNotRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
+
+        boolean studyIdNotRequired = false;
+        validator = new VepAnnotationGeneratorStepParametersValidator(studyIdNotRequired);
         validator.validate(new JobParameters(requiredParameters));
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/VepInputGeneratorStepParametersValidatorTest.java
@@ -53,7 +53,6 @@ public class VepInputGeneratorStepParametersValidatorTest {
         requiredParameters.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
                                new JobParameter("dbCollectionsVariantName"));
         requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("dbName"));
-        requiredParameters.put(JobParametersNames.INPUT_STUDY_ID, new JobParameter("inputStudyId"));
         requiredParameters.put(JobParametersNames.INPUT_VCF_ID, new JobParameter("inputVcfId"));
         requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
 
@@ -84,12 +83,6 @@ public class VepInputGeneratorStepParametersValidatorTest {
     @Test(expected = JobParametersInvalidException.class)
     public void dbNameIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.DB_NAME);
-        validator.validate(new JobParameters(requiredParameters));
-    }
-
-    @Test(expected = JobParametersInvalidException.class)
-    public void inputStudyIdIsRequired() throws JobParametersInvalidException, IOException {
-        requiredParameters.remove(JobParametersNames.INPUT_STUDY_ID);
         validator.validate(new JobParameters(requiredParameters));
     }
 


### PR DESCRIPTION
This PR improves the NonAnnotatedVariantsReader, and belongs to a bigger refactor whose purpose is to have the annotation flow like this:

- annotation flow:
  - GenerateAnnotationStep
     - NonAnnotatedVariantsReader ---**current PR**---
     - VepAnnotationFileWriter
  - AnnotationLoaderStep
    - VariantAnnotationReader
    - VariantAnnotationWriter
