### PR TITLE
EVA-683 Detect when VEP hangs

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/VepProcess.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/VepProcess.java
@@ -167,20 +167,6 @@ public class VepProcess {
         });
     }
 
-    public boolean isOpen() {
-        return process != null;
-    }
-
-    public void flush() throws IOException {
-        if (!isOpen()) {
-            throw new IllegalStateException("Process must be initialized (hint: call open() before flush())");
-        }
-        tryWithTimeout(() -> {
-            processStandardInput.flush();
-            return null;
-        });
-    }
-
     private void tryWithTimeout(Callable<Void> callable) {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         Future<Void> future = executorService.submit(callable);
@@ -194,6 +180,20 @@ public class VepProcess {
             executorService.shutdown();
             executorService.shutdownNow();
         }
+    }
+
+    public boolean isOpen() {
+        return process != null;
+    }
+
+    public void flush() throws IOException {
+        if (!isOpen()) {
+            throw new IllegalStateException("Process must be initialized (hint: call open() before flush())");
+        }
+        tryWithTimeout(() -> {
+            processStandardInput.flush();
+            return null;
+        });
     }
 
     /**


### PR DESCRIPTION
It seems that when VEP hangs (due to the unnoticed death of some of its inner threads probably), we continue writing into the standard input (stdin) of VEP, but it won't write anything more, nor will consume more data from its stdin, so eventually the buffers get filled and it turns out that in the OutputStream class the `write` method can also block (just as `read`), but doesn't provide any "write with timeout" method.

So, what we have to do is keep track of the time we spent writing, and stop the step if the timeout is reached. 