### PR TITLE
EVA-741 The parameters from completed executions should not be reused

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJob.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Scope;
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlowOptional;
 import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 import uk.ac.ebi.eva.pipeline.parameters.validation.job.AggregatedVcfJobParametersValidator;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.AGGREGATED_VCF_JOB;
@@ -76,7 +77,7 @@ public class AggregatedVcfJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(AGGREGATED_VCF_JOB)
-                .incrementer(new RunIdIncrementer())
+                .incrementer(new NewJobIncrementer())
                 .validator(new AggregatedVcfJobParametersValidator());
         FlowJobBuilder builder = jobBuilder
                 .flow(variantLoaderStep)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
@@ -23,7 +23,6 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.job.flow.Flow;
-import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.ANNOTATE_VARIANTS_JOB;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_FLOW;
@@ -67,7 +67,7 @@ public class AnnotationJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(ANNOTATE_VARIANTS_JOB)
-                .incrementer(new RunIdIncrementer());
+                .incrementer(new NewJobIncrementer());
         return jobBuilder.start(annotation).build().build();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/DatabaseInitializationJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/DatabaseInitializationJob.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Scope;
 
 import uk.ac.ebi.eva.pipeline.jobs.steps.CreateDatabaseIndexesStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.GeneLoaderStep;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.CREATE_DATABASE_INDEXES_STEP;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENES_LOAD_STEP;
@@ -67,7 +68,7 @@ public class DatabaseInitializationJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(INIT_DATABASE_JOB)
-                .incrementer(new RunIdIncrementer());
+                .incrementer(new NewJobIncrementer());
 
         return jobBuilder
                 .start(createDatabaseIndexesStep)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJob.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Scope;
 import uk.ac.ebi.eva.pipeline.jobs.steps.DropFilesByStudyStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.DropSingleStudyVariantsStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.PullFilesAndStatisticsByStudyStep;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 import uk.ac.ebi.eva.pipeline.parameters.validation.job.DropStudyJobParametersValidator;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.DROP_FILES_BY_STUDY_STEP;
@@ -73,7 +74,7 @@ public class DropStudyJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(DROP_STUDY_JOB)
-                .incrementer(new RunIdIncrementer())
+                .incrementer(new NewJobIncrementer())
                 .validator(new DropStudyJobParametersValidator());
 
         SimpleJobBuilder builder = jobBuilder

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJob.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Scope;
 import uk.ac.ebi.eva.pipeline.jobs.flows.ParallelStatisticsAndAnnotationFlow;
 import uk.ac.ebi.eva.pipeline.jobs.steps.LoadFileStep;
 import uk.ac.ebi.eva.pipeline.jobs.steps.VariantLoaderStep;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 import uk.ac.ebi.eva.pipeline.parameters.validation.job.GenotypedVcfJobParametersValidator;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENOTYPED_VCF_JOB;
@@ -77,7 +78,7 @@ public class GenotypedVcfJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(GENOTYPED_VCF_JOB)
-                .incrementer(new RunIdIncrementer())
+                .incrementer(new NewJobIncrementer())
                 .validator(new GenotypedVcfJobParametersValidator());
         FlowJobBuilder builder = jobBuilder
                 .flow(variantLoaderStep)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJob.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 import uk.ac.ebi.eva.pipeline.jobs.flows.PopulationStatisticsFlow;
+import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.CALCULATE_STATISTICS_FLOW;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.CALCULATE_STATISTICS_JOB;
@@ -58,7 +59,7 @@ public class PopulationStatisticsJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(CALCULATE_STATISTICS_JOB)
-                .incrementer(new RunIdIncrementer());
+                .incrementer(new NewJobIncrementer());
 
         return jobBuilder
                 .start(optionalStatisticsFlow)

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/NewJobIncrementer.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/NewJobIncrementer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersIncrementer;
+
+/**
+ * Incrementer that does not reuse parameters from previous completed executions.
+ */
+public class NewJobIncrementer implements JobParametersIncrementer {
+
+    private static String RUN_ID_KEY = "run.id";
+
+    private String key = RUN_ID_KEY;
+
+    /**
+     * The name of the run id in the job parameters.  Defaults to "run.id".
+     *
+     * @param key the key to set
+     */
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Increment the run.id parameter (starting with 1), and ignore the other parameters.
+     */
+    @Override
+    public JobParameters getNext(JobParameters parameters) {
+        JobParameters params = (parameters == null) ? new JobParameters() : parameters;
+
+        long id = params.getLong(key, 0L) + 1;
+        return new JobParametersBuilder().addLong(key, id).toJobParameters();
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AggregatedVcfJobTest.java
@@ -59,6 +59,8 @@ import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
 /**
@@ -111,11 +113,8 @@ public class AggregatedVcfJobTest {
                 .toJobParameters();
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
-
         // check execution flow
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertCompleted(jobExecution);
 
         Collection<StepExecution> stepExecutions = jobExecution.getStepExecutions();
         Set<String> names = stepExecutions.stream().map(StepExecution::getStepName)
@@ -161,7 +160,6 @@ public class AggregatedVcfJobTest {
                 .toJobParameters();
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.FAILED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+        assertFailed(jobExecution);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
@@ -115,7 +116,7 @@ public class AnnotationJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         assertEquals(3, jobExecution.getStepExecutions().size());
         List<StepExecution> steps = new ArrayList<>(jobExecution.getStepExecutions());
@@ -176,7 +177,7 @@ public class AnnotationJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         assertEquals(1, jobExecution.getStepExecutions().size());
         StepExecution findVariantsToAnnotateStep = new ArrayList<>(jobExecution.getStepExecutions()).get(0);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -41,6 +41,7 @@ import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -114,8 +115,7 @@ public class AnnotationJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         assertEquals(3, jobExecution.getStepExecutions().size());
         List<StepExecution> steps = new ArrayList<>(jobExecution.getStepExecutions());
@@ -176,8 +176,7 @@ public class AnnotationJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         assertEquals(1, jobExecution.getStepExecutions().size());
         StepExecution findVariantsToAnnotateStep = new ArrayList<>(jobExecution.getStepExecutions()).get(0);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJobTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertDropFiles;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertDropSingleStudy;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertPullStudy;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 /**
  * Test for {@link PopulationStatisticsJob}
@@ -99,7 +100,7 @@ public class DropStudyJobTest {
                 .toJobParameters();
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         assertDropSingleStudy(variantsCollection, STUDY_ID_TO_DROP, EXPECTED_VARIANTS_AFTER_DROP_STUDY);
         assertPullStudy(variantsCollection, STUDY_ID_TO_DROP, EXPECTED_FILE_COUNT, EXPECTED_STATS_COUNT);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/DropStudyJobTest.java
@@ -99,8 +99,7 @@ public class DropStudyJobTest {
                 .toJobParameters();
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         assertDropSingleStudy(variantsCollection, STUDY_ID_TO_DROP, EXPECTED_VARIANTS_AFTER_DROP_STUDY);
         assertPullStudy(variantsCollection, STUDY_ID_TO_DROP, EXPECTED_FILE_COUNT, EXPECTED_STATS_COUNT);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -36,11 +36,13 @@ import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.test.utils.GenotypedVcfJobTestUtils;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 
 /**
  * Test for {@link GenotypedVcfJob}
@@ -108,8 +110,7 @@ public class GenotypedVcfJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 
@@ -163,7 +164,6 @@ public class GenotypedVcfJobTest {
                 .toJobParameters();
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        assertEquals(ExitStatus.FAILED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+        assertFailed(jobExecution);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -42,6 +42,7 @@ import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 
 /**
@@ -110,7 +111,7 @@ public class GenotypedVcfJobTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
 /**
@@ -101,8 +102,7 @@ public class GenotypedVcfJobWorkflowTest {
         JobParameters jobParameters = builder.toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
-
-        assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+        assertCompleted(execution);
 
         Collection<StepExecution> stepExecutions = execution.getStepExecutions();
         Map<String, StepExecution> nameToStepExecution = stepExecutions.stream().collect(
@@ -138,8 +138,7 @@ public class GenotypedVcfJobWorkflowTest {
         JobParameters jobParameters = builder.annotationSkip(true).statisticsSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
-
-        assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+        assertCompleted(execution);
 
         Set<String> names = execution.getStepExecutions().stream().map(StepExecution::getStepName)
                 .collect(Collectors.toSet());
@@ -153,8 +152,7 @@ public class GenotypedVcfJobWorkflowTest {
         JobParameters jobParameters = builder.statisticsSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
-
-        assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+        assertCompleted(execution);
 
         Collection<StepExecution> stepExecutions = execution.getStepExecutions();
         Map<String, StepExecution> nameToStepExecution = stepExecutions.stream().collect(
@@ -185,8 +183,7 @@ public class GenotypedVcfJobWorkflowTest {
         JobParameters jobParameters = builder.annotationSkip(true).toJobParameters();
 
         JobExecution execution = jobLauncherTestUtils.launchJob(jobParameters);
-
-        assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+        assertCompleted(execution);
 
         Collection<StepExecution> stepExecutions = execution.getStepExecutions();
         Map<String, StepExecution> nameToStepExecution = stepExecutions.stream().collect(

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -88,8 +89,7 @@ public class PopulationStatisticsJobTest {
                 .toJobParameters();
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         //and the file containing statistics should exist
         File statsFile = new File(URLHelper.getVariantsStatsUri(statsDir, studyId, fileId));

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/PopulationStatisticsJobTest.java
@@ -44,6 +44,7 @@ import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
@@ -89,7 +90,7 @@ public class PopulationStatisticsJobTest {
                 .toJobParameters();
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         //and the file containing statistics should exist
         File statsFile = new File(URLHelper.getVariantsStatsUri(statsDir, studyId, fileId));

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -50,6 +50,7 @@ import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 
 
@@ -95,7 +96,7 @@ public class AnnotationLoaderStepTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_VEP_ANNOTATION_STEP, jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         //check that documents have the annotation
         DBCursor cursor = mongoRule.getCollection(dbName, collectionVariantsName).find();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationLoaderStepTest.java
@@ -42,6 +42,7 @@ import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.data.VepOutputContent;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -94,8 +95,7 @@ public class AnnotationLoaderStepTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_VEP_ANNOTATION_STEP, jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         //check that documents have the annotation
         DBCursor cursor = mongoRule.getCollection(dbName, collectionVariantsName).find();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationMetadataStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationMetadataStepTest.java
@@ -46,6 +46,7 @@ import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 /**
  * TODO jmmut remove import AnnotationJob when we add the stepLauncherTestUtils
@@ -99,7 +100,7 @@ public class AnnotationMetadataStepTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_ANNOTATION_METADATA_STEP, jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationMetadataStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/AnnotationMetadataStepTest.java
@@ -40,6 +40,7 @@ import uk.ac.ebi.eva.pipeline.parameters.MongoConnection;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.util.List;
@@ -98,8 +99,7 @@ public class AnnotationMetadataStepTest {
 
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_ANNOTATION_METADATA_STEP, jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropFilesByStudyStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropFilesByStudyStepTest.java
@@ -110,8 +110,7 @@ public class DropFilesByStudyStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.DROP_FILES_BY_STUDY_STEP,
                 jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         DBCollection filesCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
         assertDropFiles(filesCollection, STUDY_ID_TO_DROP, expectedFilesAfterDropStudy);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropFilesByStudyStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropFilesByStudyStepTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertDropFiles;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 /**
  * Test for {@link DropFilesByStudyStep}
@@ -110,7 +111,7 @@ public class DropFilesByStudyStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.DROP_FILES_BY_STUDY_STEP,
                 jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         DBCollection filesCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);
         assertDropFiles(filesCollection, STUDY_ID_TO_DROP, expectedFilesAfterDropStudy);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropSingleStudyVariantsStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropSingleStudyVariantsStepTest.java
@@ -37,6 +37,7 @@ import uk.ac.ebi.eva.pipeline.jobs.DropStudyJob;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.util.Arrays;
@@ -105,8 +106,7 @@ public class DropSingleStudyVariantsStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.DROP_SINGLE_STUDY_VARIANTS_STEP,
                 jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         DBCollection variantsCollection = mongoRule.getCollection(databaseName, COLLECTION_VARIANTS_NAME);
         assertDropSingleStudy(variantsCollection, STUDY_ID_TO_DROP, expectedVariantsAfterDropStudy);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropSingleStudyVariantsStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/DropSingleStudyVariantsStepTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertDropSingleStudy;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 /**
  * Test for {@link DropSingleStudyVariantsStep}
@@ -106,7 +107,7 @@ public class DropSingleStudyVariantsStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.DROP_SINGLE_STUDY_VARIANTS_STEP,
                 jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         DBCollection variantsCollection = mongoRule.getCollection(databaseName, COLLECTION_VARIANTS_NAME);
         assertDropSingleStudy(variantsCollection, STUDY_ID_TO_DROP, expectedVariantsAfterDropStudy);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
@@ -20,8 +20,6 @@ import com.mongodb.DBCollection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.test.JobLauncherTestUtils;
@@ -110,8 +108,7 @@ public class GenerateVepAnnotationStepTest {
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
         //Then variantsAnnotCreate step should complete correctly
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         // And VEP output should exist and annotations should be in the file
         assertTrue(vepOutput.exists());
@@ -145,8 +142,7 @@ public class GenerateVepAnnotationStepTest {
         JobExecution jobExecution = jobLauncherTestUtils
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
-        assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
-        assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+        JobTestUtils.assertFailed(jobExecution);
 
         assertTrue(!vepOutput.exists());
         List<Path> files = Files.list(Paths.get(outputDirAnnot))
@@ -161,8 +157,7 @@ public class GenerateVepAnnotationStepTest {
         JobExecution secondJobExecution = jobLauncherTestUtils
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, secondJobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, secondJobExecution.getStatus());
+        JobTestUtils.assertCompleted(secondJobExecution);
 
         assertTrue(vepOutput.exists());
         int chunks = 3;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
@@ -50,6 +50,8 @@ import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
@@ -108,7 +110,7 @@ public class GenerateVepAnnotationStepTest {
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
         //Then variantsAnnotCreate step should complete correctly
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         // And VEP output should exist and annotations should be in the file
         assertTrue(vepOutput.exists());
@@ -142,7 +144,7 @@ public class GenerateVepAnnotationStepTest {
         JobExecution jobExecution = jobLauncherTestUtils
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
-        JobTestUtils.assertFailed(jobExecution);
+        assertFailed(jobExecution);
 
         assertTrue(!vepOutput.exists());
         List<Path> files = Files.list(Paths.get(outputDirAnnot))
@@ -157,7 +159,7 @@ public class GenerateVepAnnotationStepTest {
         JobExecution secondJobExecution = jobLauncherTestUtils
                 .launchStep(BeanNames.GENERATE_VEP_ANNOTATION_STEP, jobParameters);
 
-        JobTestUtils.assertCompleted(secondJobExecution);
+        assertCompleted(secondJobExecution);
 
         assertTrue(vepOutput.exists());
         int chunks = 3;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
@@ -36,6 +36,7 @@ import uk.ac.ebi.eva.pipeline.jobs.DatabaseInitializationJob;
 import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.IndexesGeneratorStep;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
@@ -68,8 +69,7 @@ public class IndexesGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CREATE_DATABASE_INDEXES_STEP,
                 jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         DBCollection genesCollection = mongoRule.getCollection(databaseName, COLLECTION_FEATURES_NAME);
         assertEquals("[{ \"v\" : 1 , \"key\" : { \"_id\" : 1} , \"name\" : \"_id_\" , \"ns\" : \"" +
@@ -90,8 +90,7 @@ public class IndexesGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CREATE_DATABASE_INDEXES_STEP,
                 jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         DBCollection genesCollection = mongoRule.getCollection(databaseName, COLLECTION_FEATURES_NAME);
         genesCollection.insert(new BasicDBObject("_id", "example_id"));

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/IndexesGeneratorStepTest.java
@@ -40,6 +40,7 @@ import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 
 /**
@@ -69,7 +70,7 @@ public class IndexesGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CREATE_DATABASE_INDEXES_STEP,
                 jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         DBCollection genesCollection = mongoRule.getCollection(databaseName, COLLECTION_FEATURES_NAME);
         assertEquals("[{ \"v\" : 1 , \"key\" : { \"_id\" : 1} , \"name\" : \"_id_\" , \"ns\" : \"" +
@@ -90,7 +91,7 @@ public class IndexesGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CREATE_DATABASE_INDEXES_STEP,
                 jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         DBCollection genesCollection = mongoRule.getCollection(databaseName, COLLECTION_FEATURES_NAME);
         genesCollection.insert(new BasicDBObject("_id", "example_id"));

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStepTest.java
@@ -36,6 +36,7 @@ import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
 import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
@@ -82,8 +83,7 @@ public class LoadFileStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_FILE_STEP, jobParameters);
 
         //Then variantsLoad step should complete correctly
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         // And the number of documents in the DB should be equals to the number of VCF files loaded
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/LoadFileStepTest.java
@@ -40,6 +40,7 @@ import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
@@ -83,7 +84,7 @@ public class LoadFileStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_FILE_STEP, jobParameters);
 
         //Then variantsLoad step should complete correctly
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         // And the number of documents in the DB should be equals to the number of VCF files loaded
         DBCollection fileCollection = mongoRule.getCollection(databaseName, COLLECTION_FILES_NAME);

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -34,6 +34,7 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorS
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import uk.ac.ebi.eva.utils.URLHelper;
 
@@ -44,6 +45,7 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 
 /**
@@ -92,8 +94,7 @@ public class PopulationStatisticsGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP, jobParameters);
 
         //Then variantsStatsCreate step should complete correctly
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         //and the file containing statistics should exist
         assertTrue(statsFile.exists());
@@ -127,7 +128,7 @@ public class PopulationStatisticsGeneratorStepTest {
 
         // When the execute method in variantsStatsCreate is executed
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP, jobParameters);
-        assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
+        assertFailed(jobExecution);
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -45,6 +45,7 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 
@@ -94,7 +95,7 @@ public class PopulationStatisticsGeneratorStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.CALCULATE_STATISTICS_STEP, jobParameters);
 
         //Then variantsStatsCreate step should complete correctly
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         //and the file containing statistics should exist
         assertTrue(statsFile.exists());

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -29,6 +29,7 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsLoaderStep
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.io.IOException;
@@ -37,6 +38,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.copyResource;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
@@ -98,8 +100,7 @@ public class PopulationStatisticsLoaderStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_STATISTICS_STEP, jobParameters);
 
         // Then variantsStatsLoad step should complete correctly
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         // The DB docs should have the field "st"
         DBCursor cursor = mongoRule.getCollection(dbName, COLLECTION_VARIANTS_NAME).find();
@@ -147,7 +148,7 @@ public class PopulationStatisticsLoaderStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_STATISTICS_STEP, jobParameters);
         assertThat(capture.toString(), containsString(FILE_NOT_FOUND_EXCEPTION));
 
-        assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
+        assertFailed(jobExecution);
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsLoaderStepTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.copyResource;
 import static uk.ac.ebi.eva.test.utils.TestFileUtils.getResourceUrl;
@@ -100,7 +101,7 @@ public class PopulationStatisticsLoaderStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_STATISTICS_STEP, jobParameters);
 
         // Then variantsStatsLoad step should complete correctly
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         // The DB docs should have the field "st"
         DBCursor cursor = mongoRule.getCollection(dbName, COLLECTION_VARIANTS_NAME).find();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PullFilesAndStatisticsByStudyStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PullFilesAndStatisticsByStudyStepTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static uk.ac.ebi.eva.test.utils.DropStudyJobTestUtils.assertPullStudy;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 
 /**
  * Test for {@link PullFilesAndStatisticsByStudyStep}
@@ -140,7 +141,7 @@ public class PullFilesAndStatisticsByStudyStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.PULL_FILES_AND_STATISTICS_BY_STUDY_STEP,
                 jobParameters);
 
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
     }
 
     private void checkPull(String databaseName, int expectedFileCount, int expectedStatsCount) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PullFilesAndStatisticsByStudyStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PullFilesAndStatisticsByStudyStepTest.java
@@ -36,6 +36,7 @@ import uk.ac.ebi.eva.pipeline.jobs.DropStudyJob;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.data.VariantData;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import java.io.IOException;
@@ -139,8 +140,7 @@ public class PullFilesAndStatisticsByStudyStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.PULL_FILES_AND_STATISTICS_BY_STUDY_STEP,
                 jobParameters);
 
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
     }
 
     private void checkPull(String databaseName, int expectedFileCount, int expectedStatsCount) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -45,6 +45,7 @@ import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.count;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
@@ -90,7 +91,7 @@ public class VariantLoaderStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_VARIANTS_STEP, jobParameters);
 
         //Then variantsLoad step should complete correctly
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         // And the number of documents in the DB should be equals to the number of lines in the VCF file
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/VariantLoaderStepTest.java
@@ -41,6 +41,7 @@ import uk.ac.ebi.eva.pipeline.configuration.BeanNames;
 import uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob;
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 
 import static org.junit.Assert.assertEquals;
@@ -89,8 +90,7 @@ public class VariantLoaderStepTest {
         JobExecution jobExecution = jobLauncherTestUtils.launchStep(BeanNames.LOAD_VARIANTS_STEP, jobParameters);
 
         //Then variantsLoad step should complete correctly
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        JobTestUtils.assertCompleted(jobExecution);
 
         // And the number of documents in the DB should be equals to the number of lines in the VCF file
         VariantStorageManager variantStorageManager = StorageManagerFactory.getVariantStorageManager();

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertThat;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENOTYPED_VCF_JOB;
 import static uk.ac.ebi.eva.pipeline.runner.EvaPipelineJobLauncherCommandLineRunner.EXIT_WITHOUT_ERRORS;
 import static uk.ac.ebi.eva.pipeline.runner.EvaPipelineJobLauncherCommandLineRunner.SPRING_BATCH_JOB_NAME_PROPERTY;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
 /**
@@ -147,7 +148,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution jobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 
@@ -200,7 +201,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution firstJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        JobTestUtils.assertCompleted(firstJobExecution);
+        assertCompleted(firstJobExecution);
 
         assertNotNull(firstJobExecution.getJobParameters().getString(JobParametersNames.DB_NAME));
         assertNotNull(firstJobExecution.getJobParameters().getString(JobParametersNames.CONFIG_CHUNK_SIZE));
@@ -210,7 +211,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution secondJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        JobTestUtils.assertCompleted(secondJobExecution);
+        assertCompleted(secondJobExecution);
 
         assertNotNull(secondJobExecution.getJobParameters().getString(JobParametersNames.DB_NAME));
         assertNull(secondJobExecution.getJobParameters().getString(JobParametersNames.CONFIG_CHUNK_SIZE));
@@ -253,7 +254,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution jobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        JobTestUtils.assertCompleted(jobExecution);
+        assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -19,8 +19,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opencb.opencga.storage.core.StorageManagerException;
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobInstance;
@@ -36,6 +34,7 @@ import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
 import uk.ac.ebi.eva.test.utils.GenotypedVcfJobTestUtils;
+import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaCommandLineBuilder;
 
 import java.io.File;
@@ -148,7 +147,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution jobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        assertCompleted(jobExecution);
+        JobTestUtils.assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 
@@ -165,11 +164,6 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         List<JobInstance> jobInstances = jobExplorer.getJobInstances(jobName, 0, 1);
         assertFalse(jobInstances.isEmpty());
         return jobExplorer.getJobExecution(jobInstances.get(0).getInstanceId());
-    }
-
-    private void assertCompleted(JobExecution jobExecution) {
-        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
     }
 
     @Test
@@ -206,7 +200,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution firstJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        assertCompleted(firstJobExecution);
+        JobTestUtils.assertCompleted(firstJobExecution);
 
         assertNotNull(firstJobExecution.getJobParameters().getString(JobParametersNames.DB_NAME));
         assertNotNull(firstJobExecution.getJobParameters().getString(JobParametersNames.CONFIG_CHUNK_SIZE));
@@ -216,7 +210,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution secondJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        assertCompleted(secondJobExecution);
+        JobTestUtils.assertCompleted(secondJobExecution);
 
         assertNotNull(secondJobExecution.getJobParameters().getString(JobParametersNames.DB_NAME));
         assertNull(secondJobExecution.getJobParameters().getString(JobParametersNames.CONFIG_CHUNK_SIZE));
@@ -259,7 +253,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution jobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
-        assertCompleted(jobExecution);
+        JobTestUtils.assertCompleted(jobExecution);
 
         GenotypedVcfJobTestUtils.checkLoadStep(databaseName);
 

--- a/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
+++ b/src/test/java/uk/ac/ebi/eva/test/utils/JobTestUtils.java
@@ -21,6 +21,9 @@ import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 
@@ -38,6 +41,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.zip.GZIPInputStream;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -150,5 +154,15 @@ public abstract class JobTestUtils {
     public static String buildFilesDocumentString(String studyId, String fileId) {
         return "{\"" + STUDYID_FIELD + "\":\"" + studyId
                 + "\", \"" + FILEID_FIELD + "\":\"" + fileId + "\"}";
+    }
+
+    public static void assertCompleted(JobExecution jobExecution) {
+        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+    }
+
+    public static void assertFailed(JobExecution jobExecution) {
+        assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
+        assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/utils/EvaCommandLineBuilder.java
+++ b/src/test/java/uk/ac/ebi/eva/utils/EvaCommandLineBuilder.java
@@ -171,4 +171,8 @@ public class EvaCommandLineBuilder {
     public EvaCommandLineBuilder dbCollectionsAnnotationMetadataName(String name) {
         return addString(JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME, name);
     }
+
+    public EvaCommandLineBuilder chunksize(String chunksize) {
+        return addString(JobParametersNames.CONFIG_CHUNK_SIZE, chunksize);
+    }
 }


### PR DESCRIPTION
The second time a job is launched, it should only reuse parameters (that can be overwritten with the current parameters) if the job failed. Otherwise, only the new parameters should be used. 

A solution is to implement our own JobParameters incrementer, because it will be used here https://github.com/spring-projects/spring-boot/blob/master/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java#L158 (only if the job is not stopped or failed)