### PR TITLE
EVA-423 Re-annotation job

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ The contents from the configuration files can be also provided directly as comma
 * `spring.profiles.active`: "production" to keep track of half-executed jobs using a job repository database, "test" to use an in-memory database that will record a single run
 * `app.opencga.path`: Path to the OpenCGA installation folder. An `ls` in that path should show the conf, analysis, bin and libs folders.
 
+Database credentials, all these are used to connect to a MongoDB instance. See [MongoDB options documentation](https://docs.mongodb.com/manual/reference/program/mongo/#options):
+
+* `spring.data.mongodb.authentication-database`
+* `spring.data.mongodb.host`
+* `spring.data.mongodb.password`
+* `spring.data.mongodb.port`
+* `spring.data.mongodb.username`
+
 If using a persistent (not in-memory database), the following information needs to be filled in:
 
 * `job.repository.driverClassName`: JDBC-specific argument that points to the database to use for the job repository (PostgreSQL tested and supported, driver name is `org.postgresql.Driver`)
@@ -109,13 +117,24 @@ Other parameters are:
 
 * `input.pedigree`: PED file if available, in order to calculate population-based statistics.
 * `input.fasta`: Path to the FASTA file with the reference sequence, in order to generate the VEP annotation.
+* `annotation.overwrite`: False in the common case (annotate only variants without annotation) . If true, annotation in all variants will be (over)written. Please note that if the `input.study.id` parameter is specified, annotation will be limited to variants in that study.
 
 * `output.dir`: Already existing folder to store the transformed VCF and statistics files.
 * `output.dir.annotation`: Already existing folder to store VEP output files.
 * `output.dir.statistics`: Already existing folder to store statistics output files.
 
 * `app.vep.cache.path`: Path to the VEP cache root folder.
-* `app.vep.version`: Version of the VEP cache.
+* `app.vep.version`: Version of the VEP executable.
+* `app.vep.cache.version`: Version of the VEP cache.
 * `app.vep.species`: Name of the species as stored in the cache folder.
 * `app.vep.path`: Path to the VEP installation folder.
 * `app.vep.num-forks`: Number of processes to run VEP in parallel (recommended 4).
+* `app.vep.timeout`: In seconds. If VEP doesn't respond anything during this given period, the pipeline will assume that the step failed (recommended 300).
+
+* `config.chunk.size`: Size of batches across the pipeline (recommended from 100 to 5000).
+
+* `spring.data.mongodb.database`: Database name, that contain all the collections
+* `db.collections.variants.name`: Main collection. Has variant coordinates, sample information, and some statistics and annotation.
+* `db.collections.files.name`: File (and study) metadata information.
+* `db.collections.stats.name`: Main collection for statistics. The variants collection might contain a subset of this.
+* `db.collections.annotation.metadata.name`: Main collection for annotation. The variants collection might contain a subset of this.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The contents from the configuration files can be also provided directly as comma
 * `spring.profiles.active`: "production" to keep track of half-executed jobs using a job repository database, "test" to use an in-memory database that will record a single run
 * `app.opencga.path`: Path to the OpenCGA installation folder. An `ls` in that path should show the conf, analysis, bin and libs folders.
 
-Database credentials, all these are used to connect to a MongoDB instance. See [MongoDB options documentation](https://docs.mongodb.com/manual/reference/program/mongo/#options):
+Database credentials used to connect to a MongoDB instance. See [MongoDB options documentation](https://docs.mongodb.com/manual/reference/program/mongo/#options). The database and collection names are listed below in the "Database parameters" section.
 
 * `spring.data.mongodb.authentication-database`
 * `spring.data.mongodb.host`
@@ -87,14 +87,16 @@ If using a persistent (not in-memory database), the following information needs 
 Other parameters are:
 
 * `config.db.read-preference`: In a distributed Mongo environment, replica to connect to (primary or secondary, default primary).
-* `--logging.level.uk.ac.ebi.eva`: DEBUG, INFO, WARN, ERROR supported among others. Recommended DEBUG.
-* `--logging.level.org.opencb.opencga`: Recommended DEBUG.
-* `--logging.level.org.springframework`: Recommended INFO or WARN.
+* `logging.level.uk.ac.ebi.eva`: DEBUG, INFO, WARN, ERROR supported among others. Recommended DEBUG.
+* `logging.level.org.opencb.opencga`: Recommended DEBUG.
+* `logging.level.org.springframework`: Recommended INFO or WARN.
 
 
-### General job tuning
+### Job parameters
 
-* `--spring.batch.job.names`: The name of the job to run. At the moment it can be `genotyped-vcf-job`, `aggregated-vcf-job`, `annotate-variants-job`, `calculate-statistics-job` or `drop-study-job`
+#### Job configuration
+
+* `spring.batch.job.names`: The name of the job to run. At the moment it can be `genotyped-vcf-job`, `aggregated-vcf-job`, `annotate-variants-job`, `calculate-statistics-job` or `drop-study-job`
 
 Individual steps can be skipped using one of the following. This is not necessary unless they are irrelevant for the data to be processed, or some input data was generated in previous runs of the same job.
 
@@ -103,9 +105,11 @@ Individual steps can be skipped using one of the following. This is not necessar
 
 Other parameters are:
 
+* `config.chunk.size`: Size of batches across the pipeline (recommended from 100 to 5000).
+* `annotation.overwrite`: True to overwrite annotations already associated to variants. False to annotate only variants without an existing annotation. Please note that if the `input.study.id` parameter is specified, annotation will be limited to variants from that study.
 * `force.restart`: When included as command line parameter allows to restart a a job. This will also mark the last execution not finished of the same job / parameters as cancelled in the job database.
 
-### Job run tuning
+#### Job inputs
 
 * `input.vcf`: Path to the VCF to process. May be compressed.
 * `input.vcf.id`: Unique ID for the VCF to process. Could be an analysis in the SRA model (please ignore if you don't know what SRA is).
@@ -117,11 +121,24 @@ Other parameters are:
 
 * `input.pedigree`: PED file if available, in order to calculate population-based statistics.
 * `input.fasta`: Path to the FASTA file with the reference sequence, in order to generate the VEP annotation.
-* `annotation.overwrite`: False in the common case (annotate only variants without annotation) . If true, annotation in all variants will be (over)written. Please note that if the `input.study.id` parameter is specified, annotation will be limited to variants in that study.
+
+#### Job outputs
 
 * `output.dir`: Already existing folder to store the transformed VCF and statistics files.
 * `output.dir.annotation`: Already existing folder to store VEP output files.
 * `output.dir.statistics`: Already existing folder to store statistics output files.
+
+#### Database parameters
+
+Database name and collection names can be specified with these parameters. To set the database credentials, use the parameters in the "Environment" section.
+
+* `spring.data.mongodb.database`: Database name, that contain all the collections
+* `db.collections.variants.name`: Main collection. Has variant coordinates, sample information, and some statistics and annotation.
+* `db.collections.files.name`: File (and study) metadata information.
+* `db.collections.stats.name`: Main collection for statistics. The variants collection might contain a subset of this.
+* `db.collections.annotation.metadata.name`: Main collection for annotation. The variants collection might contain a subset of this.
+
+#### Configuration of third party applications
 
 * `app.vep.cache.path`: Path to the VEP cache root folder.
 * `app.vep.version`: Version of the VEP executable.
@@ -129,12 +146,4 @@ Other parameters are:
 * `app.vep.species`: Name of the species as stored in the cache folder.
 * `app.vep.path`: Path to the VEP installation folder.
 * `app.vep.num-forks`: Number of processes to run VEP in parallel (recommended 4).
-* `app.vep.timeout`: In seconds. If VEP doesn't respond anything during this given period, the pipeline will assume that the step failed (recommended 300).
-
-* `config.chunk.size`: Size of batches across the pipeline (recommended from 100 to 5000).
-
-* `spring.data.mongodb.database`: Database name, that contain all the collections
-* `db.collections.variants.name`: Main collection. Has variant coordinates, sample information, and some statistics and annotation.
-* `db.collections.files.name`: File (and study) metadata information.
-* `db.collections.stats.name`: Main collection for statistics. The variants collection might contain a subset of this.
-* `db.collections.annotation.metadata.name`: Main collection for annotation. The variants collection might contain a subset of this.
+* `app.vep.timeout`: If VEP doesn't respond in the specified number of seconds, the pipeline will assume that the step failed (recommended 300).

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/BeanNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/BeanNames.java
@@ -21,7 +21,7 @@ package uk.ac.ebi.eva.pipeline.configuration;
 public class BeanNames {
 
     public static final String GENE_READER = "gene-reader";
-    public static final String NON_ANNOTATED_VARIANTS_READER = "non-annotated-variants-reader";
+    public static final String VARIANTS_READER = "variants-reader";
     public static final String VARIANT_ANNOTATION_READER = "variant-annotation-reader";
     public static final String VARIANT_READER = "variant-reader";
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/NonAnnotatedVariantsMongoReaderConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
+import uk.ac.ebi.eva.pipeline.parameters.AnnotationParameters;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 import uk.ac.ebi.eva.pipeline.parameters.InputParameters;
 
@@ -36,11 +37,16 @@ public class NonAnnotatedVariantsMongoReaderConfiguration {
     @StepScope
     public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(MongoOperations mongoOperations,
                                                                            DatabaseParameters databaseParameters,
-                                                                           InputParameters inputParameters) {
+                                                                           InputParameters inputParameters,
+                                                                           AnnotationParameters annotationParameters) {
+        // to overwrite annotation we have to bring all variants (non annotated and annotated)
+        boolean onlyNonAnnotated = !annotationParameters.getOverwriteAnnotation();
+
         NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader = new NonAnnotatedVariantsMongoReader(
                 mongoOperations,
                 databaseParameters.getCollectionVariantsName(),
-                inputParameters.getStudyId());
+                inputParameters.getStudyId(),
+                onlyNonAnnotated);
         nonAnnotatedVariantsMongoReader.setSaveState(false);
         return nonAnnotatedVariantsMongoReader;
     }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/readers/VariantsMongoReaderConfiguration.java
@@ -20,35 +20,35 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
 
-import uk.ac.ebi.eva.pipeline.io.readers.NonAnnotatedVariantsMongoReader;
+import uk.ac.ebi.eva.pipeline.io.readers.VariantsMongoReader;
 import uk.ac.ebi.eva.pipeline.parameters.AnnotationParameters;
 import uk.ac.ebi.eva.pipeline.parameters.DatabaseParameters;
 import uk.ac.ebi.eva.pipeline.parameters.InputParameters;
 
-import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIANTS_READER;
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANTS_READER;
 
 /**
- * Configuration to inject a NonAnnotatedVariantsMongoReader bean that reads from a mongo database in the pipeline
+ * Configuration to inject a VariantsMongoReader bean that reads from a mongo database in the pipeline
  */
 @Configuration
-public class NonAnnotatedVariantsMongoReaderConfiguration {
+public class VariantsMongoReaderConfiguration {
 
-    @Bean(NON_ANNOTATED_VARIANTS_READER)
+    @Bean(VARIANTS_READER)
     @StepScope
-    public NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader(MongoOperations mongoOperations,
-                                                                           DatabaseParameters databaseParameters,
-                                                                           InputParameters inputParameters,
-                                                                           AnnotationParameters annotationParameters) {
+    public VariantsMongoReader variantsMongoReader(MongoOperations mongoOperations,
+                                                   DatabaseParameters databaseParameters,
+                                                   InputParameters inputParameters,
+                                                   AnnotationParameters annotationParameters) {
         // to overwrite annotation we have to bring all variants (non annotated and annotated)
-        boolean onlyNonAnnotated = !annotationParameters.getOverwriteAnnotation();
+        boolean excludeAnnotated = !annotationParameters.getOverwriteAnnotation();
 
-        NonAnnotatedVariantsMongoReader nonAnnotatedVariantsMongoReader = new NonAnnotatedVariantsMongoReader(
+        VariantsMongoReader variantsMongoReader = new VariantsMongoReader(
                 mongoOperations,
                 databaseParameters.getCollectionVariantsName(),
                 inputParameters.getStudyId(),
-                onlyNonAnnotated);
-        nonAnnotatedVariantsMongoReader.setSaveState(false);
-        return nonAnnotatedVariantsMongoReader;
+                excludeAnnotated);
+        variantsMongoReader.setSaveState(false);
+        return variantsMongoReader;
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReader.java
@@ -51,7 +51,8 @@ public class NonAnnotatedVariantsMongoReader
      * @param studyId Can be the empty string or null, meaning to bring all non-annotated variants in the collection.
      * If the studyId string is not empty, bring only non-annotated variants from that study.
      */
-    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId) {
+    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId,
+                                           boolean onlyNonAnnotated) {
         setName(ClassUtils.getShortName(NonAnnotatedVariantsMongoReader.class));
         delegateReader = new MongoDbCursorItemReader();
         delegateReader.setTemplate(template);
@@ -61,8 +62,10 @@ public class NonAnnotatedVariantsMongoReader
         if (studyId != null && !studyId.isEmpty()) {
             queryBuilder.add(STUDY_KEY, studyId);
         }
-        DBObject query = queryBuilder.add("annot.ct.so", new BasicDBObject("$exists", false)).get();
-        delegateReader.setQuery(query);
+        if (onlyNonAnnotated) {
+            queryBuilder.add("annot.ct.so", new BasicDBObject("$exists", false));
+        }
+        delegateReader.setQuery(queryBuilder.get());
 
         String[] fields = {"chr", "start", "end", "ref", "alt"};
         delegateReader.setFields(fields);

--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VariantsMongoReader.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VariantsMongoReader.java
@@ -37,7 +37,7 @@ import javax.annotation.PostConstruct;
  * {@link org.springframework.batch.item.data.MongoItemReader} is using
  * pagination and it is slow with large collections
  */
-public class NonAnnotatedVariantsMongoReader
+public class VariantsMongoReader
         extends AbstractItemCountingItemStreamItemReader<VariantWrapper> implements InitializingBean {
 
     private MongoDbCursorItemReader delegateReader;
@@ -50,10 +50,11 @@ public class NonAnnotatedVariantsMongoReader
     /**
      * @param studyId Can be the empty string or null, meaning to bring all non-annotated variants in the collection.
      * If the studyId string is not empty, bring only non-annotated variants from that study.
+     * @param excludeAnnotated bring only non-annotated variants.
      */
-    public NonAnnotatedVariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId,
-                                           boolean onlyNonAnnotated) {
-        setName(ClassUtils.getShortName(NonAnnotatedVariantsMongoReader.class));
+    public VariantsMongoReader(MongoOperations template, String collectionsVariantsName, String studyId,
+                               boolean excludeAnnotated) {
+        setName(ClassUtils.getShortName(VariantsMongoReader.class));
         delegateReader = new MongoDbCursorItemReader();
         delegateReader.setTemplate(template);
         delegateReader.setCollection(collectionsVariantsName);
@@ -62,7 +63,7 @@ public class NonAnnotatedVariantsMongoReader
         if (studyId != null && !studyId.isEmpty()) {
             queryBuilder.add(STUDY_KEY, studyId);
         }
-        if (onlyNonAnnotated) {
+        if (excludeAnnotated) {
             queryBuilder.add("annot.ct.so", new BasicDBObject("$exists", false));
         }
         delegateReader.setQuery(queryBuilder.get());

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
@@ -32,18 +32,18 @@ import org.springframework.context.annotation.Scope;
 
 import uk.ac.ebi.eva.pipeline.jobs.flows.AnnotationFlow;
 import uk.ac.ebi.eva.pipeline.parameters.NewJobIncrementer;
+import uk.ac.ebi.eva.pipeline.parameters.validation.job.AnnotationJobParametersValidator;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.ANNOTATE_VARIANTS_JOB;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_FLOW;
 
 /**
  * Batch class to wire together:
- * 1) generateVepInputStep - Dump a list of variants without annotations to be used as input for VEP
- * 2) annotationCreate - run VEP
+ * 1) generateVepInputStep - Dump a list of variants without annotations and run VEP with them
  * 3) annotationLoadBatchStep - Load VEP annotations into mongo
  * <p>
- * Optional flow: variantsAnnotGenerateInput --> (annotationCreate --> annotationLoad)
- * annotationCreate and annotationLoad steps are only executed if variantsAnnotGenerateInput is generating a
+ * Optional flow: variantsAnnotGenerateInput --> (annotationLoad)
+ * annotationLoad steps are only executed if variantsAnnotGenerateInput is generating a
  * non-empty VEP input file
  *
  * TODO add a new AnnotationJobParametersValidator
@@ -67,7 +67,8 @@ public class AnnotationJob {
 
         JobBuilder jobBuilder = jobBuilderFactory
                 .get(ANNOTATE_VARIANTS_JOB)
-                .incrementer(new NewJobIncrementer());
+                .incrementer(new NewJobIncrementer())
+                .validator(new AnnotationJobParametersValidator());
         return jobBuilder.start(annotation).build().build();
     }
 

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJob.java
@@ -43,7 +43,7 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_FLOW
  * 3) annotationLoadBatchStep - Load VEP annotations into mongo
  * <p>
  * Optional flow: variantsAnnotGenerateInput --> (annotationLoad)
- * annotationLoad steps are only executed if variantsAnnotGenerateInput is generating a
+ * annotationLoad step is only executed if variantsAnnotGenerateInput is generating a
  * non-empty VEP input file
  *
  * TODO add a new AnnotationJobParametersValidator

--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStep.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import uk.ac.ebi.eva.pipeline.configuration.ChunkSizeCompletionPolicyConfiguration;
-import uk.ac.ebi.eva.pipeline.configuration.readers.NonAnnotatedVariantsMongoReaderConfiguration;
+import uk.ac.ebi.eva.pipeline.configuration.readers.VariantsMongoReaderConfiguration;
 import uk.ac.ebi.eva.pipeline.configuration.writers.VepAnnotationFileWriterConfiguration;
 import uk.ac.ebi.eva.pipeline.io.readers.AnnotationFlatFileReader;
 import uk.ac.ebi.eva.pipeline.listeners.StepProgressListener;
@@ -38,7 +38,7 @@ import uk.ac.ebi.eva.pipeline.model.VariantWrapper;
 import uk.ac.ebi.eva.pipeline.parameters.JobOptions;
 
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENERATE_VEP_ANNOTATION_STEP;
-import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.NON_ANNOTATED_VARIANTS_READER;
+import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VARIANTS_READER;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_WRITER;
 
 /**
@@ -51,14 +51,14 @@ import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.VEP_ANNOTATION_WRIT
  */
 @Configuration
 @EnableBatchProcessing
-@Import({NonAnnotatedVariantsMongoReaderConfiguration.class, VepAnnotationFileWriterConfiguration.class,
+@Import({VariantsMongoReaderConfiguration.class, VepAnnotationFileWriterConfiguration.class,
         ChunkSizeCompletionPolicyConfiguration.class})
 public class GenerateVepAnnotationStep {
 
     private static final Logger logger = LoggerFactory.getLogger(GenerateVepAnnotationStep.class);
 
     @Autowired
-    @Qualifier(NON_ANNOTATED_VARIANTS_READER)
+    @Qualifier(VARIANTS_READER)
     private ItemStreamReader<VariantWrapper> nonAnnotatedVariantsReader;
 
     @Autowired

--- a/src/main/java/uk/ac/ebi/eva/pipeline/model/VariantWrapper.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/model/VariantWrapper.java
@@ -25,12 +25,13 @@ public class VariantWrapper {
     private Variant variant;
     private String strand = "+";
 
-    public VariantWrapper(Variant variant) {
-        this.variant = variant.copyInEnsemblFormat();
+    public VariantWrapper(String chromosome, int start, int end, String reference, String alternate) {
+        this(new Variant(chromosome, start, end, reference, alternate));
     }
 
-    public VariantWrapper(String chromosome, int start, int end, String reference, String alternate) {
-        this.variant = new Variant(chromosome, start, end, reference, alternate).copyInEnsemblFormat();
+    public VariantWrapper(Variant variant) {
+        this.variant = variant;
+        transformToEnsemblFormat();
     }
 
     public String getChr() {
@@ -53,4 +54,15 @@ public class VariantWrapper {
         return strand;
     }
 
+    private void transformToEnsemblFormat() {
+        variant.setEnd(variant.getStart() + variant.getReference().length() - 1);
+
+        if (variant.getReference().equals("")) {
+            variant.setReference("-");
+        }
+
+        if (variant.getAlternate().equals("")) {
+            variant.setAlternate("-");
+        }
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
@@ -69,6 +69,9 @@ public class AnnotationParameters {
     @Value(PARAMETER + JobParametersNames.INPUT_FASTA + END)
     private String inputFasta;
 
+    @Value(PARAMETER + JobParametersNames.ANNOTATION_OVERWRITE + END)
+    private Boolean overwriteAnnotation;
+
     public String getVepPath() {
         return vepPath;
     }
@@ -99,6 +102,10 @@ public class AnnotationParameters {
 
     public String getInputFasta() {
         return inputFasta;
+    }
+
+    public Boolean getOverwriteAnnotation() {
+        return overwriteAnnotation;
     }
 
     public String getVepOutput() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/AnnotationParameters.java
@@ -69,7 +69,7 @@ public class AnnotationParameters {
     @Value(PARAMETER + JobParametersNames.INPUT_FASTA + END)
     private String inputFasta;
 
-    @Value(PARAMETER + JobParametersNames.ANNOTATION_OVERWRITE + END)
+    @Value(PARAMETER + JobParametersNames.ANNOTATION_OVERWRITE + "']?:false}")
     private Boolean overwriteAnnotation;
 
     public String getVepPath() {

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobParametersNames.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/JobParametersNames.java
@@ -94,7 +94,9 @@ public class JobParametersNames {
 
     public static final String STATISTICS_SKIP = "statistics.skip";
 
-    public static final String STATISTICS_OVERWRITE = "statistics.overwrite";
+    public static final String STATISTICS_OVERWRITE = "statistics.overwrite";   // FIXME this is only used in tests
+
+    public static final String ANNOTATION_OVERWRITE = "annotation.overwrite";
 
 
     /*

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/AnnotationOverwriteValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/AnnotationOverwriteValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters.validation;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.JobParametersValidator;
+
+import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+
+/**
+ * Checks that the option to overwrite annotation has been filled in and it is "true" or "false".
+ *
+ * Throws JobParametersInvalidException If the overwrite annotation option is null or empty or any text different
+ * from 'true' or 'false'
+ */
+public class AnnotationOverwriteValidator implements JobParametersValidator {
+
+    @Override
+    public void validate(JobParameters parameters) throws JobParametersInvalidException {
+        String annotationOverwriteValue = parameters.getString(JobParametersNames.ANNOTATION_OVERWRITE);
+
+        ParametersValidatorUtil.checkIsValidString(
+                annotationOverwriteValue, JobParametersNames.ANNOTATION_OVERWRITE);
+        ParametersValidatorUtil.checkIsBoolean(
+                annotationOverwriteValue,JobParametersNames.ANNOTATION_OVERWRITE);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters.validation.job;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.JobParametersValidator;
+import org.springframework.batch.core.job.CompositeJobParametersValidator;
+import org.springframework.batch.core.job.DefaultJobParametersValidator;
+
+import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationLoaderStepParametersValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.step.AnnotationMetadataStepParametersValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.step.GenerateVepAnnotationStepParametersValidator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates the job parameters necessary to execute an {@link uk.ac.ebi.eva.pipeline.jobs.AnnotationJob}
+ */
+public class AnnotationJobParametersValidator extends DefaultJobParametersValidator {
+
+    @Override
+    public void validate(JobParameters parameters) throws JobParametersInvalidException {
+        compositeJobParametersValidator(parameters).validate(parameters);
+    }
+
+    private CompositeJobParametersValidator compositeJobParametersValidator(JobParameters jobParameters) {
+        List<JobParametersValidator> jobParametersValidators = new ArrayList<>();
+
+        boolean studyIdRequired = false;
+
+        jobParametersValidators.add(new GenerateVepAnnotationStepParametersValidator(studyIdRequired));
+        jobParametersValidators.add(new AnnotationLoaderStepParametersValidator(studyIdRequired));
+        jobParametersValidators.add(new AnnotationMetadataStepParametersValidator());
+
+        CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();
+        compositeJobParametersValidator.setValidators(jobParametersValidators);
+        return compositeJobParametersValidator;
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationMetadataStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationMetadataStepParametersValidator.java
@@ -36,6 +36,7 @@ public class AnnotationMetadataStepParametersValidator extends DefaultJobParamet
 
     public AnnotationMetadataStepParametersValidator() {
         super(new String[]{JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME,
+                           JobParametersNames.DB_NAME,
                            JobParametersNames.APP_VEP_VERSION,
                            JobParametersNames.APP_VEP_CACHE_VERSION},
                 new String[]{});

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidator.java
@@ -23,9 +23,14 @@ import org.springframework.batch.core.job.DefaultJobParametersValidator;
 
 import uk.ac.ebi.eva.pipeline.jobs.steps.GenerateVepAnnotationStep;
 import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+import uk.ac.ebi.eva.pipeline.parameters.validation.AnnotationOverwriteValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.ConfigChunkSizeValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.DbCollectionsVariantsNameValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.DbNameValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.InputFastaValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.InputStudyIdValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.InputVcfIdValidator;
+import uk.ac.ebi.eva.pipeline.parameters.validation.OptionalValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.OutputDirAnnotationValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.VepCachePathValidator;
 import uk.ac.ebi.eva.pipeline.parameters.validation.VepCacheSpeciesValidator;
@@ -49,13 +54,16 @@ public class GenerateVepAnnotationStepParametersValidator extends DefaultJobPara
     private boolean isStudyIdRequired;
 
     public GenerateVepAnnotationStepParametersValidator(boolean isStudyIdRequired) {
-        super(new String[]{JobParametersNames.APP_VEP_CACHE_PATH,
+        super(new String[]{JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
+                           JobParametersNames.DB_NAME,
+                           JobParametersNames.APP_VEP_CACHE_PATH,
                            JobParametersNames.APP_VEP_CACHE_SPECIES,
                            JobParametersNames.APP_VEP_CACHE_VERSION,
                            JobParametersNames.APP_VEP_NUMFORKS,
                            JobParametersNames.APP_VEP_PATH,
                            JobParametersNames.APP_VEP_TIMEOUT,
                            JobParametersNames.INPUT_FASTA,
+                           JobParametersNames.ANNOTATION_OVERWRITE,
                            JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
         this.isStudyIdRequired = isStudyIdRequired;
@@ -70,19 +78,28 @@ public class GenerateVepAnnotationStepParametersValidator extends DefaultJobPara
     private CompositeJobParametersValidator compositeJobParametersValidator() {
         List<JobParametersValidator> jobParametersValidators = new ArrayList<>();
         Collections.addAll(jobParametersValidators,
+                new AnnotationOverwriteValidator(),
+                new DbCollectionsVariantsNameValidator(),
+                new DbNameValidator(),
+                new InputFastaValidator(),
+                new OutputDirAnnotationValidator(),
                 new VepCachePathValidator(),
                 new VepCacheSpeciesValidator(),
                 new VepCacheVersionValidator(),
                 new VepNumForksValidator(),
                 new VepPathValidator(),
                 new VepTimeoutValidator(),
-                new InputFastaValidator(),
-                new OutputDirAnnotationValidator()
+                new OptionalValidator(new ConfigChunkSizeValidator(), JobParametersNames.CONFIG_CHUNK_SIZE)
         );
 
         if (isStudyIdRequired) {
             jobParametersValidators.add(new InputStudyIdValidator());
             jobParametersValidators.add(new InputVcfIdValidator());
+        } else {
+            jobParametersValidators.add(
+                    new OptionalValidator(new InputStudyIdValidator(), JobParametersNames.INPUT_STUDY_ID));
+            jobParametersValidators.add(
+                    new OptionalValidator(new InputVcfIdValidator(), JobParametersNames.INPUT_VCF_ID));
         }
 
         CompositeJobParametersValidator compositeJobParametersValidator = new CompositeJobParametersValidator();

--- a/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidator.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidator.java
@@ -54,16 +54,16 @@ public class GenerateVepAnnotationStepParametersValidator extends DefaultJobPara
     private boolean isStudyIdRequired;
 
     public GenerateVepAnnotationStepParametersValidator(boolean isStudyIdRequired) {
-        super(new String[]{JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
-                           JobParametersNames.DB_NAME,
+        super(new String[]{JobParametersNames.ANNOTATION_OVERWRITE,
                            JobParametersNames.APP_VEP_CACHE_PATH,
                            JobParametersNames.APP_VEP_CACHE_SPECIES,
                            JobParametersNames.APP_VEP_CACHE_VERSION,
                            JobParametersNames.APP_VEP_NUMFORKS,
                            JobParametersNames.APP_VEP_PATH,
                            JobParametersNames.APP_VEP_TIMEOUT,
+                           JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME,
+                           JobParametersNames.DB_NAME,
                            JobParametersNames.INPUT_FASTA,
-                           JobParametersNames.ANNOTATION_OVERWRITE,
                            JobParametersNames.OUTPUT_DIR_ANNOTATION},
               new String[]{});
         this.isStudyIdRequired = isStudyIdRequired;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/NonAnnotatedVariantsMongoReaderTest.java
@@ -100,8 +100,9 @@ public class NonAnnotatedVariantsMongoReaderTest {
         MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
                 mongoMappingContext);
 
+        boolean onlyNonAnnotated = true;
         NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
-                mongoOperations, COLLECTION_VARIANTS_NAME, study);
+                mongoOperations, COLLECTION_VARIANTS_NAME, study, onlyNonAnnotated);
         mongoItemReader.open(executionContext);
 
         int itemCount = 0;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/VariantsMongoReaderTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/readers/VariantsMongoReaderTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * {@link NonAnnotatedVariantsMongoReader}
+ * {@link VariantsMongoReader}
  * input: a variants collection address
  * output: a DBObject each time `.read()` is called, with at least: chr, start, annot
  */
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertNull;
 @ActiveProfiles(Application.VARIANT_ANNOTATION_MONGO_PROFILE)
 @TestPropertySource({"classpath:test-mongo.properties"})
 @ContextConfiguration(classes = {MongoConnection.class, MongoMappingContext.class})
-public class NonAnnotatedVariantsMongoReaderTest {
+public class VariantsMongoReaderTest {
 
     private static final String COLLECTION_VARIANTS_NAME = "variants";
 
@@ -80,7 +80,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
     public TemporaryMongoRule mongoRule = new TemporaryMongoRule();
 
     @Test
-    public void shouldReadVariantsWithoutAnnotationFieldInStudy() throws Exception {
+    public void shouldReadVariantsWithoutAnnotationFieldInAStudy() throws Exception {
         checkNonAnnotatedVariantsRead(EXPECTED_NON_ANNOTATED_VARIANTS_IN_STUDY, STUDY_ID);
     }
 
@@ -90,7 +90,7 @@ public class NonAnnotatedVariantsMongoReaderTest {
     }
 
     @Test
-    public void shouldReadVariantsWithoutAnnotationFieldInAllStudiesUsingNull() throws Exception {
+    public void shouldReadVariantsWithoutAnnotationFieldInAllStudiesWhenNoStudySpecified() throws Exception {
         checkNonAnnotatedVariantsRead(EXPECTED_NON_ANNOTATED_VARIANTS_IN_DB, null);
     }
 
@@ -104,9 +104,9 @@ public class NonAnnotatedVariantsMongoReaderTest {
         MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
                 mongoMappingContext);
 
-        boolean onlyNonAnnotated = true;
-        NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
-                mongoOperations, COLLECTION_VARIANTS_NAME, study, onlyNonAnnotated);
+        boolean excludeAnnotated = true;
+        VariantsMongoReader mongoItemReader = new VariantsMongoReader(
+                mongoOperations, COLLECTION_VARIANTS_NAME, study, excludeAnnotated);
         mongoItemReader.open(executionContext);
 
         int itemCount = 0;
@@ -131,13 +131,18 @@ public class NonAnnotatedVariantsMongoReaderTest {
     }
 
     @Test
-    public void shouldReadVariantsInAllStudies() throws Exception {
+    public void shouldReadVariantsInAStudy() throws Exception {
         checkAllVariantsRead(EXPECTED_VARIANTS_IN_STUDY, STUDY_ID);
     }
 
     @Test
-    public void shouldReadVariantsInAllStudiesUsingNull() throws Exception {
+    public void shouldReadVariantsInAllStudies() throws Exception {
         checkAllVariantsRead(EXPECTED_VARIANTS_IN_DB, ALL_STUDIES);
+    }
+
+    @Test
+    public void shouldReadVariantsInAllStudiesWhenNoStudySpecified() throws Exception {
+        checkAllVariantsRead(EXPECTED_VARIANTS_IN_DB, null);
     }
 
     private void checkAllVariantsRead(int expectedVariants, String study) throws Exception {
@@ -150,9 +155,9 @@ public class NonAnnotatedVariantsMongoReaderTest {
         MongoOperations mongoOperations = MongoConfiguration.getMongoOperations(databaseName, mongoConnection,
                 mongoMappingContext);
 
-        boolean onlyNonAnnotated = false;
-        NonAnnotatedVariantsMongoReader mongoItemReader = new NonAnnotatedVariantsMongoReader(
-                mongoOperations, COLLECTION_VARIANTS_NAME, study, onlyNonAnnotated);
+        boolean excludeAnnotated = false;
+        VariantsMongoReader mongoItemReader = new VariantsMongoReader(
+                mongoOperations, COLLECTION_VARIANTS_NAME, study, excludeAnnotated);
         mongoItemReader.open(executionContext);
 
         int itemCount = 0;

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/AnnotationJobTest.java
@@ -96,17 +96,19 @@ public class AnnotationJobTest {
         File vepOutput = new File(URLHelper.resolveVepOutput(outputDirAnnot, INPUT_STUDY_ID, INPUT_VCF_ID));
         String vepOutputName = vepOutput.getName();
         temporaryFolderRule.newFile(vepOutputName);
+        File fasta = temporaryFolderRule.newFile();
 
         JobParameters jobParameters = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionAnnotationMetadataName(COLLECTION_ANNOTATION_METADATA_NAME)
                 .collectionVariantsName(COLLECTION_VARIANTS_NAME)
                 .databaseName(dbName)
-                .inputFasta("")
+                .inputFasta(fasta.getAbsolutePath())
                 .inputStudyId(INPUT_STUDY_ID)
                 .inputVcfId(INPUT_VCF_ID)
                 .outputDirAnnotation(outputDirAnnot)
                 .vepCachePath("")
-                .vepCacheSpecies("")
+                .vepCacheSpecies("human")
                 .vepCacheVersion("80")
                 .vepNumForks("4")
                 .vepPath(getResource(MOCK_VEP).getPath())
@@ -157,19 +159,21 @@ public class AnnotationJobTest {
     public void noVariantsToAnnotateOnlyGenerateAnnotationStepShouldRun() throws Exception {
         String dbName = mongoRule.getRandomTemporaryDatabaseName();
         String outputDirAnnot = temporaryFolderRule.getRoot().getAbsolutePath();
+        File fasta = temporaryFolderRule.newFile();
 
         JobParameters jobParameters = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionAnnotationMetadataName(COLLECTION_ANNOTATION_METADATA_NAME)
                 .collectionVariantsName(COLLECTION_VARIANTS_NAME)
                 .databaseName(dbName)
-                .inputFasta("")
+                .inputFasta(fasta.getAbsolutePath())
                 .inputStudyId(INPUT_STUDY_ID)
                 .inputVcfId(INPUT_VCF_ID)
                 .outputDirAnnotation(outputDirAnnot)
                 .vepCachePath("")
-                .vepCacheSpecies("")
+                .vepCacheSpecies("Human")
                 .vepCacheVersion("80")
-                .vepNumForks("")
+                .vepNumForks("4")
                 .vepPath(getResource(MOCK_VEP).getPath())
                 .vepTimeout("60")
                 .vepVersion("80")

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobTest.java
@@ -87,6 +87,7 @@ public class GenotypedVcfJobTest {
 
         // Run the Job
         JobParameters jobParameters = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionAnnotationMetadataName(GenotypedVcfJobTestUtils.COLLECTION_ANNOTATION_METADATA_NAME)
                 .collectionFilesName(GenotypedVcfJobTestUtils.COLLECTION_FILES_NAME)
                 .collectionVariantsName(GenotypedVcfJobTestUtils.COLLECTION_VARIANTS_NAME)
@@ -141,6 +142,7 @@ public class GenotypedVcfJobTest {
         File fasta = temporaryFolderRule.newFile();
 
         JobParameters jobParameters = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionAnnotationMetadataName(GenotypedVcfJobTestUtils.COLLECTION_ANNOTATION_METADATA_NAME)
                 .collectionFilesName(GenotypedVcfJobTestUtils.COLLECTION_FILES_NAME)
                 .collectionVariantsName(GenotypedVcfJobTestUtils.COLLECTION_VARIANTS_NAME)

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/GenotypedVcfJobWorkflowTest.java
@@ -217,6 +217,7 @@ public class GenotypedVcfJobWorkflowTest {
         File fasta = temporaryFolderRule.newFile();
 
         EvaJobParameterBuilder evaJobParameterBuilder = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionFilesName("files")
                 .collectionVariantsName("variants")
                 .collectionAnnotationMetadataName("annotationMetadata")

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/GenerateVepAnnotationStepTest.java
@@ -97,6 +97,7 @@ public class GenerateVepAnnotationStepTest {
                 .inputStudyId(STUDY_ID)
                 .inputVcfId(FILE_ID)
                 .outputDirAnnotation(outputDirAnnot)
+                .annotationOverwrite("false")
                 .vepCachePath("")
                 .vepCacheSpecies("")
                 .vepCacheVersion("")
@@ -127,6 +128,7 @@ public class GenerateVepAnnotationStepTest {
         int chunkSize = 100;
 
         JobParameters jobParameters = new EvaJobParameterBuilder()
+                .annotationOverwrite("false")
                 .collectionVariantsName(collectionVariantsName)
                 .chunkSize(Integer.toString(chunkSize))
                 .databaseName(databaseName)

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -41,6 +41,7 @@ import uk.ac.ebi.eva.utils.URLHelper;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -100,6 +101,8 @@ public class PopulationStatisticsGeneratorStepTest {
         //and the file containing statistics should exist
         assertTrue(statsFile.exists());
         assertTrue(sourceStatsFile.exists());
+        HashMap hashMap = new HashMap();
+        hashMap.putIfAbsent()
     }
 
     /**

--- a/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/jobs/steps/PopulationStatisticsGeneratorStepTest.java
@@ -18,8 +18,6 @@ package uk.ac.ebi.eva.pipeline.jobs.steps;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.test.JobLauncherTestUtils;
@@ -34,16 +32,13 @@ import uk.ac.ebi.eva.pipeline.jobs.steps.tasklets.PopulationStatisticsGeneratorS
 import uk.ac.ebi.eva.test.configuration.BatchTestConfiguration;
 import uk.ac.ebi.eva.test.rules.PipelineTemporaryFolderRule;
 import uk.ac.ebi.eva.test.rules.TemporaryMongoRule;
-import uk.ac.ebi.eva.test.utils.JobTestUtils;
 import uk.ac.ebi.eva.utils.EvaJobParameterBuilder;
 import uk.ac.ebi.eva.utils.URLHelper;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
@@ -101,8 +96,6 @@ public class PopulationStatisticsGeneratorStepTest {
         //and the file containing statistics should exist
         assertTrue(statsFile.exists());
         assertTrue(sourceStatsFile.exists());
-        HashMap hashMap = new HashMap();
-        hashMap.putIfAbsent()
     }
 
     /**

--- a/src/test/java/uk/ac/ebi/eva/pipeline/model/VariantWrapperTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/model/VariantWrapperTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.ebi.eva.pipeline.model;
+
+import org.junit.Test;
+
+import uk.ac.ebi.eva.commons.models.data.Variant;
+import uk.ac.ebi.eva.pipeline.io.mappers.VariantVcfFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * VEP input format uses a different end than we. These tests check that we comply with the examples in the VEP
+ * documentation at: www.ensembl.org/info/docs/tools/vep/vep_formats.html ("Default" and "VCF" sections)
+ */
+public class VariantWrapperTest {
+
+    private static final String FILE_ID = "fid";
+
+    private static final String STUDY_ID = "sid";
+
+    private VariantVcfFactory factory = new VariantVcfFactory();
+
+    @Test
+    public void transformInsertionsToEnsembleCoordinates() throws Exception {
+        VariantWrapper insertion;
+        insertion = new VariantWrapper("1", 12601, 12601, "", "C");
+        assertEquals(12601, insertion.getStart());
+        assertEquals(12600, insertion.getEnd());
+        assertEquals("-/C", insertion.getRefAlt());
+
+        insertion = new VariantWrapper("20", 4, 5, "", "A");
+        assertEquals(4, insertion.getStart());
+        assertEquals(3, insertion.getEnd());
+        assertEquals("-/A", insertion.getRefAlt());
+    }
+
+    @Test
+    public void transformDeletionToEnsembleCoordinates() throws Exception {
+        VariantWrapper deletion;
+        deletion = new VariantWrapper("1", 12600, 12602, "CGT", "");
+        assertEquals(12600, deletion.getStart());
+        assertEquals(12602, deletion.getEnd());
+        assertEquals("CGT/-", deletion.getRefAlt());
+
+        deletion = new VariantWrapper("20", 3, 3, "C", "");
+        assertEquals(3, deletion.getStart());
+        assertEquals(3, deletion.getEnd());
+        assertEquals("C/-", deletion.getRefAlt());
+    }
+
+    @Test
+    public void transformSnvToEnsembleCoordinates() throws Exception {
+        VariantWrapper insertion = new VariantWrapper("20", 3, 3, "C", "G");
+        assertEquals(3, insertion.getStart());
+        assertEquals(3, insertion.getEnd());
+        assertEquals("C/G", insertion.getRefAlt());
+    }
+
+    @Test
+    public void transformInsertionFromVcfToEnsemblCoordinates() throws Exception {
+        String line = "20\t3\t.\tC\tCA\t.\t.\t.";
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(1, result.size());
+
+        int start = result.get(0).getStart();
+        String reference = result.get(0).getReference();
+        String alternate = result.get(0).getAlternate();
+
+        assertEquals(4, start);
+        assertEquals("", reference);
+        assertEquals("A", alternate);
+
+        VariantWrapper insertion = new VariantWrapper(result.get(0).getChromosome(), start, result.get(0).getEnd(),
+                                                      reference, alternate);
+        assertEquals(4, insertion.getStart());
+        assertEquals(3, insertion.getEnd());
+        assertEquals("-/A", insertion.getRefAlt());
+    }
+
+    @Test
+    public void transformDeletionFromVcfToEnsemblCoordinates() throws Exception {
+        String line = "20\t2\t.\tTC\tT\t.\t.\t.";
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(1, result.size());
+
+        int start = result.get(0).getStart();
+        String reference = result.get(0).getReference();
+        String alternate = result.get(0).getAlternate();
+
+        assertEquals(3, start);
+        assertEquals("C", reference);
+        assertEquals("", alternate);
+
+        VariantWrapper insertion = new VariantWrapper(result.get(0).getChromosome(), start, result.get(0).getEnd(),
+                                                      reference, alternate);
+        assertEquals(3, insertion.getStart());
+        assertEquals(3, insertion.getEnd());
+        assertEquals("C/-", insertion.getRefAlt());
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/AnnotationOverwriteValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/AnnotationOverwriteValidatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.pipeline.parameters.validation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+
+import uk.ac.ebi.eva.pipeline.parameters.JobParametersNames;
+
+public class AnnotationOverwriteValidatorTest {
+
+    private AnnotationOverwriteValidator validator;
+
+    private JobParametersBuilder jobParametersBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new AnnotationOverwriteValidator();
+    }
+
+    @Test
+    public void annotationOverwriteIsTrue() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "true");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test
+    public void annotationOverwriteIsTrueAllCapital() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "TRUE");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test
+    public void annotationOverwriteIsFalse() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "false");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test
+    public void annotationOverwriteIsFalseAllCapital() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "FALSE");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void annotationOverwriteIsNotValid() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "blabla");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void annotationOverwriteIsEmpty() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, "");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void annotationOverwriteIsWhitespace() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, " ");
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void annotationOverwriteIsNull() throws JobParametersInvalidException {
+        jobParametersBuilder = new JobParametersBuilder();
+        jobParametersBuilder.addString(JobParametersNames.ANNOTATION_OVERWRITE, null);
+        validator.validate(jobParametersBuilder.toJobParameters());
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidatorTest.java
@@ -72,7 +72,6 @@ public class AnnotationJobParametersValidatorTest {
         optionalParameters = new TreeMap<>();
         optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
         optionalParameters.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, new JobParameter("true"));
-        optionalParameters.put(JobParametersNames.STATISTICS_OVERWRITE, new JobParameter("true"));
     }
 
     // The next tests show behaviour about the required parameters

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/AnnotationJobParametersValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 EMBL - European Bioinformatics Institute
+ * Copyright 2015-2017 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,68 +29,50 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Tests that the arguments necessary to run a {@link uk.ac.ebi.eva.pipeline.jobs.AggregatedVcfJob} are
+ * Tests that the arguments necessary to run a {@link uk.ac.ebi.eva.pipeline.jobs.GenotypedVcfJob} are
  * correctly validated
  */
-public class AggregatedVcfJobParametersValidatorTest {
+public class AnnotationJobParametersValidatorTest {
 
-    private AggregatedVcfJobParametersValidator validator;
+    private AnnotationJobParametersValidator validator;
 
     @Rule
     public PipelineTemporaryFolderRule temporaryFolder = new PipelineTemporaryFolderRule();
 
     private Map<String, JobParameter> requiredParameters;
 
-    private Map<String, JobParameter> annotationParameters;
-
     private Map<String, JobParameter> optionalParameters;
 
     @Before
     public void setUp() throws Exception {
-        validator = new AggregatedVcfJobParametersValidator();
+        validator = new AnnotationJobParametersValidator();
         final String dir = temporaryFolder.getRoot().getCanonicalPath();
 
         requiredParameters = new TreeMap<>();
 
-        // variant load step
-        requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("database"));
+        requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("eva_testing"));
         requiredParameters.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, new JobParameter("variants"));
-        requiredParameters.put(JobParametersNames.INPUT_STUDY_ID, new JobParameter("inputStudyId"));
-        requiredParameters.put(JobParametersNames.INPUT_VCF_ID, new JobParameter("inputVcfId"));
-        requiredParameters.put(JobParametersNames.INPUT_VCF_AGGREGATION, new JobParameter("NONE"));
-        requiredParameters.put(JobParametersNames.INPUT_VCF,
-                new JobParameter(temporaryFolder.newFile().getCanonicalPath()));
-
-        // file load step
-        requiredParameters.put(JobParametersNames.DB_COLLECTIONS_FILES_NAME, new JobParameter("collectionsFilesName"));
-        requiredParameters.put(JobParametersNames.INPUT_STUDY_NAME, new JobParameter("inputStudyName"));
-        requiredParameters.put(JobParametersNames.INPUT_STUDY_TYPE, new JobParameter("COLLECTION"));
-
-        // annotation
-        requiredParameters.put(JobParametersNames.ANNOTATION_SKIP, new JobParameter("false"));
-
-        annotationParameters = new TreeMap<>();
-        annotationParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
-        annotationParameters.put(JobParametersNames.APP_VEP_CACHE_SPECIES, new JobParameter("Human"));
-        annotationParameters.put(JobParametersNames.APP_VEP_CACHE_VERSION, new JobParameter("100_A"));
-        annotationParameters.put(JobParametersNames.APP_VEP_VERSION, new JobParameter("80"));
-        annotationParameters.put(JobParametersNames.APP_VEP_NUMFORKS, new JobParameter("6"));
-        annotationParameters.put(JobParametersNames.APP_VEP_TIMEOUT, new JobParameter("600"));
-        annotationParameters.put(JobParametersNames.ANNOTATION_OVERWRITE, new JobParameter("false"));
-        annotationParameters.put(JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME,
+        requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION, new JobParameter(dir));
+        requiredParameters.put(JobParametersNames.APP_VEP_CACHE_SPECIES, new JobParameter("Human"));
+        requiredParameters.put(JobParametersNames.APP_VEP_CACHE_VERSION, new JobParameter("100_A"));
+        requiredParameters.put(JobParametersNames.APP_VEP_VERSION, new JobParameter("80"));
+        requiredParameters.put(JobParametersNames.APP_VEP_NUMFORKS, new JobParameter("6"));
+        requiredParameters.put(JobParametersNames.APP_VEP_TIMEOUT, new JobParameter("600"));
+        requiredParameters.put(JobParametersNames.ANNOTATION_OVERWRITE, new JobParameter("false"));
+        requiredParameters.put(JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME,
                 new JobParameter("annotationMetadata"));
-        annotationParameters.put(JobParametersNames.APP_VEP_CACHE_PATH,
+        requiredParameters.put(JobParametersNames.APP_VEP_CACHE_PATH,
                 new JobParameter(temporaryFolder.getRoot().getCanonicalPath()));
-        annotationParameters.put(JobParametersNames.APP_VEP_PATH,
+        requiredParameters.put(JobParametersNames.APP_VEP_PATH,
                 new JobParameter(temporaryFolder.newFile().getCanonicalPath()));
-        annotationParameters.put(JobParametersNames.INPUT_FASTA,
+        requiredParameters.put(JobParametersNames.INPUT_FASTA,
                 new JobParameter(temporaryFolder.newFile().getCanonicalPath()));
-
 
         // optionals
         optionalParameters = new TreeMap<>();
         optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
         optionalParameters.put(JobParametersNames.CONFIG_RESTARTABILITY_ALLOW, new JobParameter("true"));
+        optionalParameters.put(JobParametersNames.STATISTICS_OVERWRITE, new JobParameter("true"));
     }
 
     // The next tests show behaviour about the required parameters
@@ -99,25 +81,25 @@ public class AggregatedVcfJobParametersValidatorTest {
     public void allJobParametersAreValid() throws JobParametersInvalidException {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
-        parameters.putAll(annotationParameters);
         parameters.putAll(optionalParameters);
         validator.validate(new JobParameters(parameters));
     }
+
     @Test
     public void allRequiredJobParametersAreValid() throws JobParametersInvalidException {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
-        parameters.putAll(annotationParameters);
         validator.validate(new JobParameters(parameters));
     }
 
     @Test(expected = JobParametersInvalidException.class)
-    public void dbNameIsRequiredSkippingAnnotation() throws JobParametersInvalidException {
+    public void dbNameIsRequiredSkippingAnnotationAndStats() throws JobParametersInvalidException {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
         parameters.putAll(optionalParameters);
         parameters.remove(JobParametersNames.DB_NAME);
         parameters.put(JobParametersNames.ANNOTATION_SKIP, new JobParameter("true"));
+        parameters.put(JobParametersNames.STATISTICS_SKIP, new JobParameter("true"));
         validator.validate(new JobParameters(parameters));
     }
 
@@ -126,43 +108,27 @@ public class AggregatedVcfJobParametersValidatorTest {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
         parameters.putAll(optionalParameters);
-        parameters.putAll(annotationParameters);
         parameters.remove(JobParametersNames.DB_NAME);
+        parameters.put(JobParametersNames.STATISTICS_SKIP, new JobParameter("true"));
         validator.validate(new JobParameters(parameters));
     }
 
-    // The next tests show what happens when not all the annotation parameters are present
-
-    @Test
-    public void annotationParametersAreNotRequiredIfAnnotationIsSkipped() throws JobParametersInvalidException {
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbNameIsRequiredWithoutSkippingStats() throws JobParametersInvalidException {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
         parameters.putAll(optionalParameters);
         parameters.put(JobParametersNames.ANNOTATION_SKIP, new JobParameter("true"));
+        parameters.remove(JobParametersNames.DB_NAME);
         validator.validate(new JobParameters(parameters));
     }
 
     @Test(expected = JobParametersInvalidException.class)
-    public void annotationParametersAreRequiredIfAnnotationIsNotSkipped() throws JobParametersInvalidException {
+    public void dbNameIsRequiredWithoutSkippingAnnotationAndStats() throws JobParametersInvalidException {
         Map<String, JobParameter> parameters = new TreeMap<>();
         parameters.putAll(requiredParameters);
         parameters.putAll(optionalParameters);
-        validator.validate(new JobParameters(parameters));
-    }
-
-    /**
-     * The parameter APP_VEP_CACHE_SPECIES is chosen as one belonging to the annotation parameters. We don't check
-     * for every annotation parameter, because in AnnotationLoaderStepParametersValidatorTest and
-     * GenerateVepAnnotationStepParametersValidatorTest, it is already
-     * checked that every missing required parameter makes the validation fail.
-     */
-    @Test(expected = JobParametersInvalidException.class)
-    public void appVepCacheSpeciesIsRequiredIfAnnotationIsNotSkipped() throws JobParametersInvalidException {
-        Map<String, JobParameter> parameters = new TreeMap<>();
-        parameters.putAll(requiredParameters);
-        parameters.putAll(annotationParameters);
-        parameters.putAll(optionalParameters);
-        parameters.remove(JobParametersNames.APP_VEP_CACHE_SPECIES);
+        parameters.remove(JobParametersNames.DB_NAME);
         validator.validate(new JobParameters(parameters));
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/job/GenotypedVcfJobParametersValidatorTest.java
@@ -80,6 +80,7 @@ public class GenotypedVcfJobParametersValidatorTest {
         annotationParameters.put(JobParametersNames.APP_VEP_VERSION, new JobParameter("80"));
         annotationParameters.put(JobParametersNames.APP_VEP_NUMFORKS, new JobParameter("6"));
         annotationParameters.put(JobParametersNames.APP_VEP_TIMEOUT, new JobParameter("600"));
+        annotationParameters.put(JobParametersNames.ANNOTATION_OVERWRITE, new JobParameter("false"));
         annotationParameters.put(JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME,
                 new JobParameter("annotationMetadata"));
         annotationParameters.put(JobParametersNames.APP_VEP_CACHE_PATH,

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationMetadataStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/AnnotationMetadataStepParametersValidatorTest.java
@@ -44,17 +44,23 @@ public class AnnotationMetadataStepParametersValidatorTest {
     @Before
     public void setUp() throws Exception {
         validator = new AnnotationMetadataStepParametersValidator();
-        final String dir = temporaryFolder.getRoot().getCanonicalPath();
 
         requiredParameters = new TreeMap<>();
         requiredParameters.put(JobParametersNames.DB_COLLECTIONS_ANNOTATION_METADATA_NAME,
                                new JobParameter("dbCollectionsVariantName"));
+        requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("eva_testing"));
         requiredParameters.put(JobParametersNames.APP_VEP_VERSION, new JobParameter("80"));
         requiredParameters.put(JobParametersNames.APP_VEP_CACHE_VERSION, new JobParameter("81"));
     }
 
     @Test
     public void allJobParametersAreValid() throws JobParametersInvalidException, IOException {
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbNameIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.DB_NAME);
         validator.validate(new JobParameters(requiredParameters));
     }
 

--- a/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/parameters/validation/step/GenerateVepAnnotationStepParametersValidatorTest.java
@@ -40,6 +40,8 @@ public class GenerateVepAnnotationStepParametersValidatorTest {
 
     private Map<String, JobParameter> requiredParameters;
 
+    private Map<String, JobParameter> optionalParameters;
+
     @Rule
     public PipelineTemporaryFolderRule temporaryFolderRule = new PipelineTemporaryFolderRule();
 
@@ -49,6 +51,9 @@ public class GenerateVepAnnotationStepParametersValidatorTest {
         validator = new GenerateVepAnnotationStepParametersValidator(studyIdRequired);
 
         requiredParameters = new TreeMap<>();
+
+        requiredParameters.put(JobParametersNames.DB_NAME, new JobParameter("eva_testing"));
+        requiredParameters.put(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, new JobParameter("variants"));
         requiredParameters.put(JobParametersNames.APP_VEP_CACHE_PATH,
                                new JobParameter(temporaryFolderRule.getRoot().getCanonicalPath()));
         requiredParameters.put(JobParametersNames.APP_VEP_CACHE_SPECIES, new JobParameter("Human"));
@@ -63,11 +68,34 @@ public class GenerateVepAnnotationStepParametersValidatorTest {
         requiredParameters.put(JobParametersNames.OUTPUT_DIR_ANNOTATION,
                                new JobParameter(temporaryFolderRule.getRoot().getCanonicalPath()));
         requiredParameters.put(JobParametersNames.APP_VEP_TIMEOUT, new JobParameter("600"));
+        requiredParameters.put(JobParametersNames.ANNOTATION_OVERWRITE, new JobParameter("false"));
 
+        optionalParameters = new TreeMap<>();
+        optionalParameters.put(JobParametersNames.CONFIG_CHUNK_SIZE, new JobParameter("100"));
     }
 
     @Test
     public void allJobParametersAreValid() throws JobParametersInvalidException, IOException {
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test
+    public void allJobParametersIncludingOptionalAreValid() throws JobParametersInvalidException, IOException {
+        Map<String, JobParameter> parameters = new TreeMap<>();
+        parameters.putAll(requiredParameters);
+        parameters.putAll(optionalParameters);
+        validator.validate(new JobParameters(parameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbNameIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.DB_NAME);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void dbCollectionsVariantsNameIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME);
         validator.validate(new JobParameters(requiredParameters));
     }
 
@@ -146,6 +174,12 @@ public class GenerateVepAnnotationStepParametersValidatorTest {
     @Test(expected = JobParametersInvalidException.class)
     public void appVepTimeoutIsRequired() throws JobParametersInvalidException, IOException {
         requiredParameters.remove(JobParametersNames.APP_VEP_TIMEOUT);
+        validator.validate(new JobParameters(requiredParameters));
+    }
+
+    @Test(expected = JobParametersInvalidException.class)
+    public void annotationOverwriteIsRequired() throws JobParametersInvalidException, IOException {
+        requiredParameters.remove(JobParametersNames.ANNOTATION_OVERWRITE);
         validator.validate(new JobParameters(requiredParameters));
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -135,6 +135,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
                 .vepNumForks("1")
                 .appVepTimeout("60")
                 .vepVersion("1")
+                .annotationOverwrite("false")
                 .inputFasta(fasta.getAbsolutePath())
                 .configDbReadPreference("secondary")
                 .dbCollectionsVariantsName("variants")
@@ -239,6 +240,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
                 getResource(GENOTYPED_PROPERTIES_FILE).getAbsolutePath());
 
         evaPipelineJobLauncherCommandLineRunner.run(new EvaCommandLineBuilder()
+                .annotationOverwrite("false")
                 .inputVcf(inputFile.getAbsolutePath())
                 .inputVcfId(GenotypedVcfJobTestUtils.INPUT_VCF_ID)
                 .inputStudyId(GenotypedVcfJobTestUtils.INPUT_STUDY_ID)

--- a/src/test/java/uk/ac/ebi/eva/utils/EvaCommandLineBuilder.java
+++ b/src/test/java/uk/ac/ebi/eva/utils/EvaCommandLineBuilder.java
@@ -106,6 +106,10 @@ public class EvaCommandLineBuilder {
         return addBoolean(JobParametersNames.ANNOTATION_SKIP, annotationSkip);
     }
 
+    public EvaCommandLineBuilder annotationOverwrite(String annotationOverwrite) {
+        return addString(JobParametersNames.ANNOTATION_OVERWRITE, annotationOverwrite);
+    }
+
     public EvaCommandLineBuilder statisticsSkip(boolean statisticsSkip) {
         return addBoolean(JobParametersNames.STATISTICS_SKIP, statisticsSkip);
     }

--- a/src/test/java/uk/ac/ebi/eva/utils/EvaJobParameterBuilder.java
+++ b/src/test/java/uk/ac/ebi/eva/utils/EvaJobParameterBuilder.java
@@ -25,6 +25,11 @@ import java.util.Date;
 
 public class EvaJobParameterBuilder extends JobParametersBuilder {
 
+    public EvaJobParameterBuilder annotationOverwrite(String outputDirAnnotation) {
+        addParameter(JobParametersNames.ANNOTATION_OVERWRITE, new JobParameter(outputDirAnnotation));
+        return this;
+    }
+
     public EvaJobParameterBuilder inputStudyId(String inputStudyId) {
         addParameter(JobParametersNames.INPUT_STUDY_ID, new JobParameter(inputStudyId));
         return this;
@@ -64,11 +69,11 @@ public class EvaJobParameterBuilder extends JobParametersBuilder {
         addParameter(JobParametersNames.DB_NAME, new JobParameter(databaseName));
         return this;
     }
-
     public EvaJobParameterBuilder collectionVariantsName(String collectionVariantsName) {
         addParameter(JobParametersNames.DB_COLLECTIONS_VARIANTS_NAME, new JobParameter(collectionVariantsName));
         return this;
     }
+
     public EvaJobParameterBuilder collectionFilesName(String collectionFilesName) {
         addParameter(JobParametersNames.DB_COLLECTIONS_FILES_NAME, new JobParameter(collectionFilesName));
         return this;


### PR DESCRIPTION
The job was almost done, the changes to notice are:
- this pr goes into develop, as it works with the old annotation structure (everything in the variants collection). Consequently, this part will be reviewed after EVA-698 is merged in a upstream/feature branch.
- added parameter `annotation.overwrite` to delete the current annotation and write it again. This can also be limited to a single study.
- added (and reviewed) parameters validators (and tests).
- updated README.md, some parameters were missing.