### PR TITLE
EVA-880 Reduce chance of timeouts in (re-)annotation search

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/configuration/io/readers/VariantsMongoReaderConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/configuration/io/readers/VariantsMongoReaderConfiguration.java
@@ -48,6 +48,7 @@ public class VariantsMongoReaderConfiguration {
                 annotationParameters.getVepVersion(),
                 annotationParameters.getVepCacheVersion(),
                 inputParameters.getStudyId(),
+                inputParameters.getVcfId(),
                 excludeAnnotated);
         variantsMongoReader.setSaveState(false);
         return variantsMongoReader;


### PR DESCRIPTION
When a big study is loaded and only a small amount of variants are pending to annotate, the search could timeout. In order to reduce the chance of this happening, an additional filter has been added to `VariantsMongoReader`. Now it restricts by file (being loaded) in addition to the study.

I'm not sure about the nesting (if no study is specified it doesn't matter whether the file is) as a concept, but in terms of performance is the only thing that makes sense...