### PR TITLE
Ignored all vcf records which reported non variant sites

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
@@ -225,10 +225,11 @@ public class VariantVcfFactory {
 
     protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
                                         String[] alternateAlleles, String[] secondaryAlternates,
-                                        int alternateAlleleIdx) throws NonStandardCompliantSampleField {
+                                        int alternateAlleleIdx) throws NonStandardCompliantSampleField,NotAVariantException {
         String[] formatFields = variant.getSourceEntry(fileId, studyId).getFormat().split(":");
-
+        
         for (int i = 9; i < fields.length; i++) {
+            int ctr=0;
             Map<String, String> map = new TreeMap<>();
 
             // Fill map of a sample
@@ -239,12 +240,24 @@ public class VariantVcfFactory {
             for (int j = 0; j < sampleFields.length; j++) {
                 String formatField = formatFields[j];
                 String sampleField = processSampleField(alternateAlleleIdx, formatField, sampleFields[j]);
-
+                if(formatField.equals("GT"))
+                {
+                    if(sampleField.equals("0/0") || sampleField.equals("0|0") || sampleField.equals("./."))
+                    {
+                        ctr++;
+                    }
+                }
                 map.put(formatField, sampleField);
             }
-
+            if(ctr==sampleFields.length)
+            {
+                throw new NotAVariantException;
+            }
+            else
+            {
             // Add sample to the variant entry in the source file
             variant.getSourceEntry(fileId, studyId).addSampleData(map);
+            }
         }
     }
 
@@ -314,7 +327,7 @@ public class VariantVcfFactory {
         variant.getSourceEntry(fileId, studyId).addAttribute("src", line);
     }
 
-    protected void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele) {
+    protected void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele)throws NotAVariantException;  {
         VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
 
         for (String var : info.split(";")) {
@@ -333,10 +346,18 @@ public class VariantVcfFactory {
                         break;
                     case "AF":
                         // TODO For now, only one alternate is supported
+                        if(splits[1].equals("0"))
+                        {
+                           throw new NotAVariantException;  
+                        }
                         String[] frequencies = splits[1].split(",");
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;
-//                    case "AN":
+                  case "AN":
+                        if(splits[1].equals("0"))
+                        {
+                           throw new NotAVariantException;  
+                        }
 //                        // TODO For now, only two alleles (reference and one alternate) are supported, but this should be changed
 //                        file.addAttribute(splits[0], "2");
 //                        break;


### PR DESCRIPTION
Description:
Ignored all vcf records which reported non variant sites, by putting  some condition checks and ignoring those records for which condition holds true.
fixes #132 

file modified:
    https://github.com/EBIvariation/eva-pipeline/blob/develop/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java