### PR TITLE
Added feature property to initialize-database.properties

### DIFF
--- a/examples/initialize-database.properties
+++ b/examples/initialize-database.properties
@@ -6,3 +6,6 @@ input.gtf=/path/to/sample.gtf.gz
 
 # Database configuration
 spring.data.mongodb.database=
+
+# Feature Collection Name
+db.collections.features.name=

--- a/examples/initialize-database.properties
+++ b/examples/initialize-database.properties
@@ -7,5 +7,4 @@ input.gtf=/path/to/sample.gtf.gz
 # Database configuration
 spring.data.mongodb.database=
 
-# Feature Collection Name
 db.collections.features.name=


### PR DESCRIPTION
The purpose of this PR is to add `db.collections.features.name` to the `initialize-database.properties` which is a required property to run the job `init-database-job`