### PR TITLE
EVA-2287 Avoid removing chr prefix

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactory.java
@@ -64,7 +64,7 @@ public class VariantVcfFactory {
             throw new IllegalArgumentException("Not enough fields provided (min 8)");
         }
 
-        String chromosome = getChromosomeWithoutPrefix(fields);
+        String chromosome = fields[0];
         int position = getPosition(fields);
         Set<String> ids = new HashSet<>(); //EVA-942 - Ignore IDs submitted through VCF
         String reference = getReference(fields);
@@ -102,21 +102,6 @@ public class VariantVcfFactory {
         }
 
         return variants;
-    }
-
-    /**
-     * Replace "chr" references only at the beginning of the chromosome name.
-     * For instance, tomato has SL2.40ch00 and that should be kept that way
-     */
-    private String getChromosomeWithoutPrefix(String[] fields) {
-        String chromosome = fields[0];
-        boolean ignoreCase = true;
-        int startOffset = 0;
-        String prefixToRemove = "chr";
-        if (chromosome.regionMatches(ignoreCase, startOffset, prefixToRemove, startOffset, prefixToRemove.length())) {
-            return chromosome.substring(prefixToRemove.length());
-        }
-        return chromosome;
     }
 
     private int getPosition(String[] fields) {

--- a/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/io/mappers/VariantVcfFactoryTest.java
@@ -47,19 +47,20 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testRemoveChrPrefixInAnyCase() {
-        List<Variant> expResult = new LinkedList<>();
-        expResult.add(new Variant("1", 1000, 1000, "T", "G"));
         String line;
 
         line = "chr1\t1000\t.\tT\tG\t.\t.\t.";
+        List<Variant> expResult = Collections.singletonList(new Variant("chr1", 1000, 1000, "T", "G"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
         line = "Chr1\t1000\t.\tT\tG\t.\t.\t.";
+        expResult = Collections.singletonList(new Variant("Chr1", 1000, 1000, "T", "G"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
         line = "CHR1\t1000\t.\tT\tG\t.\t.\t.";
+        expResult = Collections.singletonList(new Variant("CHR1", 1000, 1000, "T", "G"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
     }


### PR DESCRIPTION
Unfortunately `eva-pipeline` is not using the `variation-commons` library and have its own implementation for the Readers although they seem very similar. We should probably refactor this repo and use variation commons. See [EVA-2300](https://www.ebi.ac.uk/panda/jira/browse/EVA-2300)