### PR TITLE
EVA-1893 - Ensure that annotation process does not fail due to empty VEP output

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/processors/VepAnnotationProcessor.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/jobs/steps/processors/VepAnnotationProcessor.java
@@ -68,8 +68,9 @@ public class VepAnnotationProcessor implements ItemProcessor<List<EnsemblVariant
         vepProcess.close();
         writer.close();
 
-        String[] lines = writer.getBuffer().toString().split("\n"); // TODO is it possible to refactor this?
-        return Arrays.asList(lines);
+        String fullVEPOutput = writer.getBuffer().toString();
+        String[] lines = fullVEPOutput.split("\n"); // TODO is it possible to refactor this?
+        return fullVEPOutput.trim().equals("")? null : Arrays.asList(lines);
     }
 
     private void logBatch(List<EnsemblVariant> ensemblVariants) {


### PR DESCRIPTION
Skip empty VEP output from being processed by returning null. See [here](https://docs.spring.io/spring-batch/docs/current/reference/html/domain.html#item-reader).