### PR TITLE
EVA-2580 - Fix for resumability of jobs

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
@@ -69,12 +69,8 @@ public class CommandLineRunnerUtils {
     private static boolean areParametersEquivalentExceptRunId(JobParameters parameters1, JobParameters parameters2) {
         Map<String, JobParameter> firstJobParameterMap = parameters1.getParameters();
         Map<String, JobParameter> secondJobParameterMap = parameters2.getParameters();
-        if (parameters1.getParameters().containsKey(RUN_ID_PARAMETER_NAME)) {
-            firstJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
-        }
-        if (parameters2.getParameters().containsKey(RUN_ID_PARAMETER_NAME)) {
-            secondJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
-        }
+        firstJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
+        secondJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
         return firstJobParameterMap.equals(secondJobParameterMap);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
@@ -11,9 +11,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.NoSuchJobException;
-import org.springframework.batch.core.repository.JobRepository;
-import uk.ac.ebi.eva.commons.batch.exception.NoPreviousJobExecutionException;
-import uk.ac.ebi.eva.commons.batch.job.JobStatusManager;
 
 import java.util.Comparator;
 import java.util.List;

--- a/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/runner/CommandLineRunnerUtils.java
@@ -1,0 +1,83 @@
+package uk.ac.ebi.eva.pipeline.runner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Entity;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.NoSuchJobException;
+import org.springframework.batch.core.repository.JobRepository;
+import uk.ac.ebi.eva.commons.batch.exception.NoPreviousJobExecutionException;
+import uk.ac.ebi.eva.commons.batch.job.JobStatusManager;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class CommandLineRunnerUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(CommandLineRunnerUtils.class);
+
+    private static final String RUN_ID_PARAMETER_NAME = "run.id";
+
+    public static JobParameters addRunIDToJobParameters(String jobName, JobExplorer jobExplorer,
+                                                        JobParameters jobParameters) {
+        JobExecution lastJobExecution = getLastJobExecution(jobName, jobExplorer, jobParameters);
+        if (lastJobExecution != null) {
+            Long runIdParameterFromLastExecution = lastJobExecution.getJobParameters()
+                                                                   .getLong(RUN_ID_PARAMETER_NAME);
+            if (runIdParameterFromLastExecution != 0 && lastJobExecution.getStatus() == BatchStatus.FAILED) {
+                // Spring Batch 4 uses all job parameters (including run.id) to detect previous instances of a job - see https://github.com/spring-projects/spring-boot/blob/86fb39d5c5f474fe3544159270d4c4e2d01d43ef/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java#L222
+                // as opposed to Spring 3 which uses only job name - see https://github.com/spring-projects/spring-boot/blob/541890f0e003a6e346f2234102c97105ab1292ee/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherCommandLineRunner.java#L131
+                // Therefore, run.id needs to be supplied for failed jobs in order for the job to be detected and resumed - see https://stackoverflow.com/a/59198742/2601814
+                return new JobParametersBuilder(jobParameters)
+                        .addLong(RUN_ID_PARAMETER_NAME, runIdParameterFromLastExecution).toJobParameters();
+            }
+        }
+
+        return jobParameters;
+    }
+
+    public static JobExecution getLastJobExecution(String jobName, JobExplorer jobExplorer,
+                                                   JobParameters previousJobParameters) {
+        int previousJobInstanceCount = getPreviousJobInstanceCount(jobName, jobExplorer);
+
+        List<JobInstance> jobInstanceList = jobExplorer.getJobInstances(jobName, 0, previousJobInstanceCount);
+        List<JobExecution> matchingJobExecutions;
+
+        for (JobInstance jobInstance : jobInstanceList) {
+            matchingJobExecutions = jobExplorer.getJobExecutions(jobInstance);
+            for (JobExecution jobExecution : matchingJobExecutions) {
+                if (areParametersEquivalentExceptRunId(jobExecution.getJobParameters(), previousJobParameters)) {
+                    return matchingJobExecutions.stream().max(Comparator.comparingLong(Entity::getId)).get();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static int getPreviousJobInstanceCount(String jobName, JobExplorer jobExplorer) {
+        try {
+            return jobExplorer.getJobInstanceCount(jobName);
+        } catch (NoSuchJobException ex) {
+            return 0;
+        }
+    }
+
+    private static boolean areParametersEquivalentExceptRunId(JobParameters parameters1, JobParameters parameters2) {
+        Map<String, JobParameter> firstJobParameterMap = parameters1.getParameters();
+        Map<String, JobParameter> secondJobParameterMap = parameters2.getParameters();
+        if (parameters1.getParameters().containsKey(RUN_ID_PARAMETER_NAME)) {
+            firstJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
+        }
+        if (parameters2.getParameters().containsKey(RUN_ID_PARAMETER_NAME)) {
+            secondJobParameterMap.remove(RUN_ID_PARAMETER_NAME);
+        }
+        return firstJobParameterMap.equals(secondJobParameterMap);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunner.java
+++ b/src/main/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunner.java
@@ -95,6 +95,8 @@ public class EvaPipelineJobLauncherCommandLineRunner extends JobLauncherCommandL
 
     private JobRepository jobRepository;
 
+    private final JobExplorer jobExplorer;
+
     private JobRegistry jobRegistry;
 
     private JobParametersConverter converter;
@@ -109,6 +111,7 @@ public class EvaPipelineJobLauncherCommandLineRunner extends JobLauncherCommandL
         super(jobLauncher, jobExplorer);
         jobs = Collections.emptySet();
         this.jobRepository = jobRepository;
+        this.jobExplorer = jobExplorer;
         abnormalExit = false;
         converter = new DefaultJobParametersConverter();
 
@@ -164,6 +167,8 @@ public class EvaPipelineJobLauncherCommandLineRunner extends JobLauncherCommandL
             checkIfPropertiesHaveBeenProvided(jobParameters);
             if (restartPreviousExecution) {
                 restartPreviousJobExecution(jobParameters);
+            } else {
+                jobParameters = CommandLineRunnerUtils.addRunIDToJobParameters(jobName, jobExplorer, jobParameters);
             }
             launchJob(jobParameters);
         } catch (NoJobToExecuteException | NoParametersHaveBeenPassedException | UnexpectedFileEncodingException

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -51,8 +51,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static uk.ac.ebi.eva.pipeline.configuration.BeanNames.GENOTYPED_VCF_JOB;
 import static uk.ac.ebi.eva.pipeline.runner.EvaPipelineJobLauncherCommandLineRunner.EXIT_WITHOUT_ERRORS;
+import static uk.ac.ebi.eva.pipeline.runner.EvaPipelineJobLauncherCommandLineRunner.EXIT_WITH_ERRORS;
 import static uk.ac.ebi.eva.pipeline.runner.EvaPipelineJobLauncherCommandLineRunner.SPRING_BATCH_JOB_NAME_PROPERTY;
 import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertCompleted;
+import static uk.ac.ebi.eva.test.utils.JobTestUtils.assertFailed;
 import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 
 /**
@@ -289,5 +291,70 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
 
         assertEquals(EvaPipelineJobLauncherCommandLineRunner.EXIT_WITH_ERRORS,
                 evaPipelineJobLauncherCommandLineRunner.getExitCode());
+    }
+
+    @Test
+    public void resumeFailingJobFromCorrectStep() throws Exception {
+        String databaseName = mongoRule.getRandomTemporaryDatabaseName();
+        File inputFile = GenotypedVcfJobTestUtils.getInputFile();
+
+        String outputDirStats = temporaryFolderRule.newFolder().getAbsolutePath();
+        String outputDirAnnotation = temporaryFolderRule.newFolder().getAbsolutePath();
+
+        File fasta = temporaryFolderRule.newFile();
+
+        // To test job resumption with an identical parameter set, we use a single path to VEP symlinked to first a
+        // failing mock VEP, then to a successful one.
+        String mockVepPath = temporaryFolderRule.newFolder().getAbsolutePath() + "/mockvep_link.pl";
+        GenotypedVcfJobTestUtils.createLinkToFailingMockVep(mockVepPath);
+
+        String[] commandLine = new EvaCommandLineBuilder()
+                .annotationOverwrite("false")
+                .appVepPath(mockVepPath)
+                .appVepTimeout("60")
+                .configDbReadPreference("secondary")
+                .databaseName(databaseName)
+                .dbCollectionsAnnotationMetadataName("annotationMetadata")
+                .dbCollectionsAnnotationsName(GenotypedVcfJobTestUtils.COLLECTION_ANNOTATIONS_NAME)
+                .dbCollectionsFeaturesName("features")
+                .dbCollectionsFilesName("files")
+                .dbCollectionsStatisticsName("populationStatistics")
+                .dbCollectionsVariantsName("variants")
+                .inputFasta(fasta.getAbsolutePath())
+                .inputStudyId(GenotypedVcfJobTestUtils.INPUT_STUDY_ID)
+                .inputStudyName("small vcf")
+                .inputStudyType("COLLECTION")
+                .inputVcf(inputFile.getAbsolutePath())
+                .inputVcfAggregation("NONE")
+                .inputVcfId(GenotypedVcfJobTestUtils.INPUT_VCF_ID)
+                .outputDirAnnotation(outputDirAnnotation)
+                .outputDirStatistics(outputDirStats)
+                .vepCachePath("")
+                .vepCacheSpecies("human")
+                .vepCacheVersion("1")
+                .vepNumForks("1")
+                .vepVersion("1")
+                .build();
+
+        evaPipelineJobLauncherCommandLineRunner.setJobNames(GENOTYPED_VCF_JOB);
+        evaPipelineJobLauncherCommandLineRunner.run(commandLine);
+
+        assertEquals(EXIT_WITH_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
+
+        JobExecution firstJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
+        assertFailed(firstJobExecution);
+        long firstJobId = firstJobExecution.getJobId();
+
+        // Re-link to a working mock VEP to check resumption
+        GenotypedVcfJobTestUtils.createLinkToWorkingMockVep(mockVepPath);
+
+        evaPipelineJobLauncherCommandLineRunner.run(commandLine);
+        assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
+
+        JobExecution secondJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
+        long secondJobId = secondJobExecution.getJobId();
+        assertEquals(firstJobId, secondJobId);
+
+        // TODO do we need to check the interleaved case (as in eva-accession)?
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opencb.opencga.lib.common.Config;
 import org.opencb.opencga.storage.core.StorageManagerException;
+import org.springframework.batch.core.Entity;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobInstance;
@@ -176,7 +177,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         List<JobInstance> jobInstances = jobExplorer.getJobInstances(jobName, 0, 1);
         assertFalse(jobInstances.isEmpty());
         List<JobExecution> jobExecutions = jobExplorer.getJobExecutions(jobInstances.get(0));
-        return jobExecutions.stream().max(Comparator.comparing(JobExecution::getStartTime)).get();
+        return jobExecutions.stream().max(Comparator.comparingLong(Entity::getId)).get();
     }
 
     @Test
@@ -358,6 +359,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         long secondJobId = secondJobExecution.getJobId();
         assertEquals(firstJobId, secondJobId);
 
-        // TODO do we need to check the interleaved case (as in eva-accession)?
+        // Second job execution should only execute the steps for VEP annotation
+        assertEquals(2, secondJobExecution.getStepExecutions().size());
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
+++ b/src/test/java/uk/ac/ebi/eva/pipeline/runner/EvaPipelineJobLauncherCommandLineRunnerTest.java
@@ -41,6 +41,7 @@ import uk.ac.ebi.eva.utils.EvaCommandLineBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.hamcrest.core.StringContains.containsString;
@@ -174,7 +175,8 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
     private JobExecution getLastJobExecution(String jobName) {
         List<JobInstance> jobInstances = jobExplorer.getJobInstances(jobName, 0, 1);
         assertFalse(jobInstances.isEmpty());
-        return jobExplorer.getJobExecution(jobInstances.get(0).getInstanceId());
+        List<JobExecution> jobExecutions = jobExplorer.getJobExecutions(jobInstances.get(0));
+        return jobExecutions.stream().max(Comparator.comparing(JobExecution::getStartTime)).get();
     }
 
     @Test
@@ -352,6 +354,7 @@ public class EvaPipelineJobLauncherCommandLineRunnerTest {
         assertEquals(EXIT_WITHOUT_ERRORS, evaPipelineJobLauncherCommandLineRunner.getExitCode());
 
         JobExecution secondJobExecution = getLastJobExecution(GENOTYPED_VCF_JOB);
+        assertCompleted(secondJobExecution);
         long secondJobId = secondJobExecution.getJobId();
         assertEquals(firstJobId, secondJobId);
 

--- a/src/test/java/uk/ac/ebi/eva/test/utils/GenotypedVcfJobTestUtils.java
+++ b/src/test/java/uk/ac/ebi/eva/test/utils/GenotypedVcfJobTestUtils.java
@@ -13,6 +13,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
@@ -31,6 +34,8 @@ import static uk.ac.ebi.eva.utils.FileUtils.getResource;
 public class GenotypedVcfJobTestUtils {
 
     private static final String MOCK_VEP = "/mockvep.pl";
+
+    private static final String FAILING_MOCK_VEP = "/mockvep_writeToFile_error.pl";
 
     public static final String INPUT_VCF_ID = "1";
 
@@ -152,6 +157,22 @@ public class GenotypedVcfJobTestUtils {
 
     public static File getMockVep() {
         return getResource(MOCK_VEP);
+    }
+
+    public static File getFailingMockVep() {
+        return getResource(FAILING_MOCK_VEP);
+    }
+
+    public static Path createLinkToWorkingMockVep(String linkPathName) throws IOException {
+        Path linkPath = Paths.get(linkPathName);
+        Files.deleteIfExists(linkPath);
+        return Files.createSymbolicLink(linkPath, getMockVep().toPath());
+    }
+
+    public static Path createLinkToFailingMockVep(String linkPathName) throws IOException {
+        Path linkPath = Paths.get(linkPathName);
+        Files.deleteIfExists(linkPath);
+        return Files.createSymbolicLink(linkPath, getFailingMockVep().toPath());
     }
 
     public static String getDefaultOpencgaHome() {


### PR DESCRIPTION
Fix resumability of jobs by adding `runId` to job params when appropriate (see [here](https://github.com/EBIvariation/eva-accession/blob/0cdce9669b66bb82237f51defe85578641ab04ed/eva-accession-core/src/main/java/uk/ac/ebi/eva/accession/core/runner/CommandLineRunnerUtils.java) and [here](https://github.com/EBIvariation/eva-accession/blob/0cdce9669b66bb82237f51defe85578641ab04ed/eva-accession-clustering/src/main/java/uk/ac/ebi/eva/accession/clustering/runner/ClusteringCommandLineRunner.java#L124) for the same logic in eva-accession).