### PR TITLE
Update gitlab-ci artifact path for deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
     - deploy
 
 variables:
-    PIPELINE_ARTIFACT_PATH: target/eva-pipeline-*.jar
+    PIPELINE_ARTIFACT_PATH: target/eva-pipeline-*exec.jar
     PIPELINE_SYMLINK_NAME: "eva-pipeline.jar"
     MAVEN_SETTINGS: maven-settings.xml
     URL_MAVEN_SETTINGS: https://api.github.com/repos/EBIvariation/configuration/contents/eva-maven-settings.xml


### PR DESCRIPTION
A small change was made in an earlier PR to generate a jar that can be added as a dependency to other projects. It was being used as a dependency in the Groovy project for remediation of ref/alt.
This means the artifact name needs to be changed for deployment as the pipeline is not able to find the generated artifact